### PR TITLE
Add Windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required (VERSION 3.5)
 project (sharpSAT VERSION 1.2 LANGUAGES CXX)
 
-if (WIN32)
-    message(FATAL_ERROR "Windows is not supported at this moment")
-endif()
-
 include(GNUInstallDirs)
 
 add_library(libsharpSAT STATIC
@@ -71,22 +67,37 @@ target_include_directories(libsharpSAT
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-
-find_library(GMP_LIB gmp)
-find_library(GMPXX_LIB gmpxx)
+if (NOT WIN32)
+    find_library(GMP_LIB gmp)
+    find_library(GMPXX_LIB gmpxx)
+endif()
 
 target_link_libraries(libsharpSAT PUBLIC ${GMP_LIB} ${GMPXX_LIB})
 
+
+# On Windows we use MPIR via vcpkg and it is not integrated with
+# CMake at all. Thus we have to hack something together for now.
+if (WIN32)
+    target_include_directories(libsharpSAT PUBLIC "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/")
+    target_link_libraries(libsharpSAT PUBLIC "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/mpir.lib")
+endif()
+# The current code is a mess and abuses MSVC iterators in an invalid way
+if (MSVC)
+    target_compile_definitions(libsharpSAT PUBLIC _ITERATOR_DEBUG_LEVEL=0)
+endif()
+
 add_executable(sharpSAT src/main.cpp)
 target_link_libraries(sharpSAT libsharpSAT)
+
+
 
 if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )
     target_compile_options( libsharpSAT PRIVATE -Wall -Wextra )
     target_compile_options( sharpSAT PRIVATE -Wall -Wextra )
 endif()
 if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
-    target_compile_options( libsharpSAT PRIVATE /W4 )
-    target_compile_options( sharpSAT PRIVATE /W4 )
+    target_compile_options( libsharpSAT PRIVATE /W4 /wd4127 /wd4244 )
+    target_compile_options( sharpSAT PRIVATE /W4 /wd4127 /wd4244 )
 endif()
 
 # Keep build optimized -- Only for GCC/Clang, MSVC does Debug/Release differently

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+## Build only, no tests are present ATM
+version: "{build}"
+
+branches:
+  except:
+    - /dev-travis.+/
+
+os:
+  - Visual Studio 2017
+
+init:
+  - git config --global core.autocrlf input
+
+install:
+  - vcpkg install mpir:%PLATFORM%-windows
+
+cache:
+  - c:\tools\vcpkg\installed
+
+# Win32 and x64 are CMake-compatible solution platform names.
+# This allows us to pass %PLATFORM% to CMake -A.
+platform:
+  - x64
+
+# build Configurations, i.e. Debug, Release, etc.
+configuration:
+  - Debug
+  - Release
+
+#Cmake will autodetect the compiler, but we set the arch
+before_build:
+  - cmake -H. -BBuild -A%PLATFORM% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+
+# build with MSBuild
+build:
+  project: Build\sharpSAT.sln           # path to Visual Studio solution or project
+  parallel: true                        # enable MSBuild parallel builds
+  verbosity: normal                     # MSBuild verbosity level {quiet|minimal|normal|detailed}
+
+test_script:
+  - set CTEST_OUTPUT_ON_FAILURE=1
+  - cd Build
+  - echo %CONFIGURATION%
+  - if "%CONFIGURATION%"=="Release" ( ctest -j 2 -C %CONFIGURATION% )
+
+environment:
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true

--- a/include/sharpSAT/solver.h
+++ b/include/sharpSAT/solver.h
@@ -33,7 +33,7 @@ public:
 	 * The instance must be loaded via the \ref Instance public API
 	 * (\ref Instance::initialize, \ref Instance::add_clause and
 	 * \ref Instance::finalize).
-	 * 
+	 *
 	 * Time-limit in seconds can be set by `setTimeBound()`.
 	 *
 	 * Calculation result can be found in `statistics().exit_state_`
@@ -232,7 +232,7 @@ private:
 	void recordAllUIPCauses();
 
 	void minimizeAndStoreUIPClause(LiteralID uipLit,
-			std::vector<LiteralID> & tmp_clause, bool seen[]);
+			std::vector<LiteralID> & tmp_clause, std::vector<bool> const& seen);
 	void storeUIPClause(LiteralID uipLit, std::vector<LiteralID> & tmp_clause);
 	int getAssertionLevel() const {
 		return assertion_level_;

--- a/src/component_cache.cpp
+++ b/src/component_cache.cpp
@@ -46,9 +46,23 @@ uint64_t freeram() {
 }
 } // sharpSAT namespace
 
+
+#elif _MSC_VER
+
+#include <windows.h>
+
+uint64_t freeram() {
+    MEMORYSTATUSEX state;
+    state.dwLength = sizeof(state);
+    GlobalMemoryStatusEx(&state);
+    return state.ullAvailPhys;
+}
+
+
 #else
 // ToDo: Provide something like freeram
 #error "freeram function not provided for this platform"
+
 #endif
 
 using namespace std;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,8 +3,6 @@
 #include <iostream>
 #include <vector>
 #include <string>
-#include <sys/time.h>
-#include <sys/resource.h>
 
 using namespace std;
 using namespace sharpSAT;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -602,7 +602,7 @@ bool Solver::implicitBCP() {
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
 void Solver::minimizeAndStoreUIPClause(LiteralID uipLit,
-		vector<LiteralID> & tmp_clause, bool seen[]) {
+		vector<LiteralID> & tmp_clause, std::vector<bool> const& seen) {
 	static deque<LiteralID> clause;
 	clause.clear();
 	assertion_level_ = 0;
@@ -648,8 +648,11 @@ void Solver::recordLastUIPCauses() {
 // variables of lower dl: if seen we dont work with them anymore
 // variables of this dl: if seen we incorporate their
 // antecedent and set to unseen
-	bool seen[num_variables() + 1];
-	memset(seen, false, sizeof(bool) * (num_variables() + 1));
+
+    // ToDo:: This can cause some slowdown because of allocations.
+    //        If this proves problematic, we can cache the allocation,
+    //        as the number of variables should remain constant after init
+    std::vector<bool> seen(num_variables() + 1);
 
 	static vector<LiteralID> tmp_clause;
 	tmp_clause.clear();
@@ -742,8 +745,10 @@ void Solver::recordAllUIPCauses() {
 // variables of lower dl: if seen we dont work with them anymore
 // variables of this dl: if seen we incorporate their
 // antecedent and set to unseen
-	bool seen[num_variables() + 1];
-	memset(seen, false, sizeof(bool) * (num_variables() + 1));
+    // ToDo:: This can cause some slowdown because of allocations.
+    //        If this proves problematic, we can cache the allocation,
+    //        as the number of variables should remain constant after init
+    std::vector<bool> seen(num_variables() + 1);
 
 	static vector<LiteralID> tmp_clause;
 	tmp_clause.clear();


### PR DESCRIPTION
This adds a hacky Windows support to sharpSAT. Hacky here means that it strongly assumes that MPIR was installed by vcpkg and can be found by abusing vcpkg's toolchain file paths, and iterator debugging had to be turned off on Windows, because sharpSAT uses vectors and iterators badly.

However, it does provide CI via AppVeyor and sharpSAT can be run and linked against on Windows.

Depends on #6