### PR TITLE
Introduce strong-typing for "primitive" types.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,41 @@ matrix:
   include:
     - os: linux
       compiler: clang
-      env: COMPILER='clang++'
+      env:
+        - COMPILER='clang++'
+        - BUILD_TYPE=Debug
 
     - os: linux
       compiler: gcc
-      env: COMPILER='g++'
+      env:
+        - COMPILER='g++'
+        - BUILD_TYPE=Debug
 
     - os: osx
       osx_image: xcode9.1
       compiler: clang
-      env: COMPILER='clang++'
+      env:
+        - COMPILER='clang++'
+        - BUILD_TYPE=Debug
+
+    - os: linux
+      compiler: clang
+      env:
+        - COMPILER='clang++'
+        - BUILD_TYPE=Release
+
+    - os: linux
+      compiler: gcc
+      env:
+        - COMPILER='g++'
+        - BUILD_TYPE=Release
+
+    - os: osx
+      osx_image: xcode9.1
+      compiler: clang
+      env:
+        - COMPILER='clang++'
+        - BUILD_TYPE=Release
 
 install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
@@ -39,7 +64,7 @@ before_script:
   - cd ${TRAVIS_BUILD_DIR}
 
 script:
-  - cmake -H. -BBuild-Debug -DCMAKE_BUILD_TYPE=Debug
-  - cd Build-Debug
+  - cmake -H. -BBuild-${BUILD_TYPE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+  - cd Build-${BUILD_TYPE}
   - make -j 2
   - CTEST_OUTPUT_ON_FAILURE=1 ctest -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(libsharpSAT STATIC
     include/sharpSAT/statistics.h
     include/sharpSAT/stopwatch.h
     include/sharpSAT/structures.h
+    include/sharpSAT/unions.h
     include/sharpSAT/component_types/base_packed_component.h
     include/sharpSAT/component_types/cacheable_component.h
     include/sharpSAT/component_types/component_archetype.h

--- a/include/sharpSAT/alt_component_analyzer.h
+++ b/include/sharpSAT/alt_component_analyzer.h
@@ -43,7 +43,7 @@ public:
       std::vector<LiteralID> &lit_pool);
 
 
-  bool isUnseenAndActive(VariableIndex v){
+  bool isUnseenAndActive(VariableIndex v) {
     assert(v <= max_variable_id_);
     return archetype_.var_unseen_in_sup_comp(v);
   }
@@ -60,7 +60,7 @@ public:
       return false;
     }
   bool manageSearchOccurrenceAndScoreOf(LiteralID lit){
-    var_frequency_scores_[lit.var()]+= isActive(lit);
+    var_frequency_scores_[lit.var()] += isActive(lit);
     return manageSearchOccurrenceOf(lit);
   }
 
@@ -74,14 +74,14 @@ public:
   void setupAnalysisContext(StackLevel &top, Component & super_comp){
      archetype_.reInitialize(top,super_comp);
 
-     for (auto vt = super_comp.varsBegin(); *vt != varsSENTINEL; vt++)
-       if (isActive(*vt)) {
-         archetype_.setVar_in_sup_comp_unseen(*vt);
-         var_frequency_scores_[*vt] = 0;
+     for (auto vt = super_comp.varsBegin(); VariableIndex(*vt) != varsSENTINEL; vt++)
+       if (isActive(VariableIndex(*vt))) {
+         archetype_.setVar_in_sup_comp_unseen(VariableIndex(*vt));
+         var_frequency_scores_[VariableIndex(*vt)] = 0;
        }
 
-     for (auto itCl = super_comp.clsBegin(); *itCl != clsSENTINEL; itCl++)
-         archetype_.setClause_in_sup_comp_unseen(*itCl);
+     for (auto itCl = super_comp.clsBegin(); ClauseIndex(*itCl) != clsSENTINEL; itCl++)
+         archetype_.setClause_in_sup_comp_unseen(ClauseIndex(*itCl));
   }
 
   // returns true, iff the component found is non-trivial
@@ -102,10 +102,11 @@ public:
     return archetype_.makeComponentFromState(search_stack_.size());
   }
 
-  unsigned max_clause_id(){
+  ClauseIndex max_clause_id(){
      return max_clause_id_;
   }
-  unsigned max_variable_id(){
+
+  VariableIndex max_variable_id(){
     return max_variable_id_;
   }
 
@@ -117,8 +118,8 @@ private:
   // the id of the last clause
   // note that clause ID is the clause number,
   // different from the offset of the clause in the literal pool
-  unsigned max_clause_id_ = 0;
-  unsigned max_variable_id_ = 0;
+  ClauseIndex max_clause_id_ = ClauseIndex(0);
+  VariableIndex max_variable_id_ = VariableIndex(0);
 
   // this contains clause offsets of the clauses
   // where each variable occurs in;
@@ -133,11 +134,11 @@ private:
   std::vector<unsigned> unified_variable_links_lists_pool_;
 
 
-  std::vector<unsigned> variable_link_list_offsets_;
+  VariableIndexedVector<unsigned> variable_link_list_offsets_;
 
   LiteralIndexedVector<TriValue> & literal_values_;
 
-  std::vector<unsigned> var_frequency_scores_;
+  VariableIndexedVector<unsigned> var_frequency_scores_;
 
   ComponentArchetype  archetype_;
 
@@ -170,13 +171,13 @@ private:
   void recordComponentOf(const VariableIndex var);
 
 
-  void getClause(std::vector<unsigned> &tmp,
+  void getClause(std::vector<LiteralID> &tmp,
    		       std::vector<LiteralID>::iterator & it_start_of_cl,
-   		       LiteralID & omitLit){
+   		       VariableIndex omitVar) {
   	  tmp.clear();
   	  for (auto it_lit = it_start_of_cl;*it_lit != SENTINEL_LIT; it_lit++) {
-   		  if(it_lit->var() != omitLit.var())
-   			 tmp.push_back(it_lit->raw());
+   		  if(it_lit->var() != omitVar)
+   			 tmp.push_back(*it_lit);
    	  }
      }
 

--- a/include/sharpSAT/component_analyzer.h
+++ b/include/sharpSAT/component_analyzer.h
@@ -112,7 +112,7 @@ public:
   }
 
   //begin DEBUG
-  void test_checkArchetypeRepForClause(unsigned *pcl_ofs){
+  void test_checkArchetypeRepForClause(std::vector<unsigned>::iterator pcl_ofs){
       ClauseIndex clID = getClauseID(ClauseOfs(*pcl_ofs));
       bool all_a = true;
       for (auto itL = beginOfClause(ClauseOfs(*pcl_ofs)); *itL != SENTINEL_LIT; itL++) {
@@ -190,8 +190,8 @@ private:
       static_cast<unsigned>(cl_ofs) - CAClauseHeader::overheadInLits()]);
   }
 
-  unsigned *beginOfLinkList(VariableIndex v) {
-    return &unified_variable_links_lists_pool_[variable_link_list_offsets_[v]];
+  std::vector<unsigned>::iterator beginOfLinkList(VariableIndex v) {
+    return unified_variable_links_lists_pool_.begin() + variable_link_list_offsets_[v];
   }
 
   std::vector<LiteralID>::iterator beginOfClause(ClauseOfs cl_ofs) {

--- a/include/sharpSAT/component_analyzer.h
+++ b/include/sharpSAT/component_analyzer.h
@@ -71,14 +71,14 @@ public:
   void setupAnalysisContext(StackLevel &top, Component & super_comp){
      archetype_.reInitialize(top,super_comp);
 
-     for (auto vt = super_comp.varsBegin(); vt->var() != varsSENTINEL; vt++)
-       if (isActive(vt->var())) {
-         archetype_.setVar_in_sup_comp_unseen(vt->var());
-         var_frequency_scores_[vt->var()] = 0;
+     for (auto vt = super_comp.varsBegin(); vt->get<VariableIndex>() != varsSENTINEL; vt++)
+       if (isActive(vt->get<VariableIndex>())) {
+         archetype_.setVar_in_sup_comp_unseen(vt->get<VariableIndex>());
+         var_frequency_scores_[vt->get<VariableIndex>()] = 0;
        }
 
-     for (auto itCl = super_comp.clsBegin(); itCl->cls() != clsSENTINEL; itCl++)
-         archetype_.setClause_in_sup_comp_unseen(itCl->cls());
+     for (auto itCl = super_comp.clsBegin(); itCl->get<ClauseIndex>() != clsSENTINEL; itCl++)
+         archetype_.setClause_in_sup_comp_unseen(itCl->get<ClauseIndex>());
   }
 
   // returns true, iff the component found is non-trivial
@@ -112,10 +112,10 @@ public:
   }
 
   //begin DEBUG
-  void test_checkArchetypeRepForClause(std::vector<ClauseOfsOrVariable>::iterator pcl_ofs){
-      ClauseIndex clID = getClauseID(pcl_ofs->ofs());
+  void test_checkArchetypeRepForClause(std::vector<Variant<unsigned,ClauseOfs,VariableIndex>>::iterator pcl_ofs){
+      ClauseIndex clID = getClauseID(pcl_ofs->get<ClauseOfs>());
       bool all_a = true;
-      for (auto itL = beginOfClause(pcl_ofs->ofs()); *itL != SENTINEL_LIT; itL++) {
+      for (auto itL = beginOfClause(pcl_ofs->get<ClauseOfs>()); *itL != SENTINEL_LIT; itL++) {
         if(!isActive(*itL))
           all_a = false;
       }
@@ -145,7 +145,7 @@ private:
   // this should give better cache behaviour,
   // because all links of one variable (binary and nonbinray) are found
   // in one contiguous chunk of memory
-  std::vector<ClauseOfsOrVariable> unified_variable_links_lists_pool_;
+  std::vector<Variant<unsigned,ClauseOfs,VariableIndex>> unified_variable_links_lists_pool_;
 
   std::vector<ClauseOfs> map_clause_id_to_ofs_;
   VariableIndexedVector<unsigned> variable_link_list_offsets_;
@@ -188,7 +188,8 @@ private:
     ]);
   }
 
-  std::vector<ClauseOfsOrVariable>::iterator beginOfLinkList(VariableIndex v) {
+  std::vector<Variant<unsigned,ClauseOfs,VariableIndex>>::iterator
+  beginOfLinkList(VariableIndex v) {
     return unified_variable_links_lists_pool_.begin() + variable_link_list_offsets_[v];
   }
 

--- a/include/sharpSAT/component_management.h
+++ b/include/sharpSAT/component_management.h
@@ -128,9 +128,9 @@ void ComponentManager::recordRemainingCompsFor(StackLevel &top) {
 
    ana_.setupAnalysisContext(top, super_comp);
 
-   for (auto vt = super_comp.varsBegin(); vt->var() != varsSENTINEL; vt++)
-     if (ana_.isUnseenAndActive(vt->var()) &&
-         ana_.exploreRemainingCompOf(vt->var())) {
+   for (auto vt = super_comp.varsBegin(); vt->get<VariableIndex>() != varsSENTINEL; vt++)
+     if (ana_.isUnseenAndActive(vt->get<VariableIndex>()) &&
+         ana_.exploreRemainingCompOf(vt->get<VariableIndex>())) {
 
        Component *p_new_comp = ana_.makeComponentFromArcheType();
        CacheableComponent *packed_comp = new CacheableComponent(ana_.getArchetype().current_comp_for_caching_);

--- a/include/sharpSAT/component_management.h
+++ b/include/sharpSAT/component_management.h
@@ -128,9 +128,9 @@ void ComponentManager::recordRemainingCompsFor(StackLevel &top) {
 
    ana_.setupAnalysisContext(top, super_comp);
 
-   for (auto vt = super_comp.varsBegin(); VariableIndex(*vt) != varsSENTINEL; vt++) 
-     if (ana_.isUnseenAndActive(VariableIndex(*vt)) &&
-         ana_.exploreRemainingCompOf(VariableIndex(*vt))){
+   for (auto vt = super_comp.varsBegin(); vt->var() != varsSENTINEL; vt++)
+     if (ana_.isUnseenAndActive(vt->var()) &&
+         ana_.exploreRemainingCompOf(vt->var())) {
 
        Component *p_new_comp = ana_.makeComponentFromArcheType();
        CacheableComponent *packed_comp = new CacheableComponent(ana_.getArchetype().current_comp_for_caching_);

--- a/include/sharpSAT/component_management.h
+++ b/include/sharpSAT/component_management.h
@@ -128,9 +128,9 @@ void ComponentManager::recordRemainingCompsFor(StackLevel &top) {
 
    ana_.setupAnalysisContext(top, super_comp);
 
-   for (auto vt = super_comp.varsBegin(); *vt != varsSENTINEL; vt++)
-     if (ana_.isUnseenAndActive(*vt) &&
-         ana_.exploreRemainingCompOf(*vt)){
+   for (auto vt = super_comp.varsBegin(); VariableIndex(*vt) != varsSENTINEL; vt++) 
+     if (ana_.isUnseenAndActive(VariableIndex(*vt)) &&
+         ana_.exploreRemainingCompOf(VariableIndex(*vt))){
 
        Component *p_new_comp = ana_.makeComponentFromArcheType();
        CacheableComponent *packed_comp = new CacheableComponent(ana_.getArchetype().current_comp_for_caching_);

--- a/include/sharpSAT/component_types/base_packed_component.h
+++ b/include/sharpSAT/component_types/base_packed_component.h
@@ -8,6 +8,8 @@
 #ifndef SHARP_SAT_BASE_PACKED_COMPONENT_H_
 #define SHARP_SAT_BASE_PACKED_COMPONENT_H_
 
+#include <sharpSAT/primitive_types.h>
+
 #include <assert.h>
 #include <cstddef>
 #include <gmpxx.h>
@@ -79,7 +81,7 @@ public:
     return _bits_of_data_size;
   }
 
-  static void adjustPackSize(unsigned int maxVarId, unsigned int maxClId);
+  static void adjustPackSize(VariableIndex maxVarId, ClauseIndex maxClId);
 
   BasePackedComponent() {}
   BasePackedComponent(unsigned creation_time): creation_time_(creation_time) {}

--- a/include/sharpSAT/component_types/component.h
+++ b/include/sharpSAT/component_types/component.h
@@ -53,14 +53,16 @@ public:
 
   void closeClauseData() {
     data_.push_back(clsSENTINEL);
-    assert((clsBegin() - 1)->var() == varsSENTINEL);
+    assert((clsBegin() - 1)->get<VariableIndex>() == varsSENTINEL);
   }
 
-  std::vector<ClauseOrVariable>::const_iterator varsBegin() const {
+  std::vector<Variant<ClauseIndex,VariableIndex>>::const_iterator
+  varsBegin() const {
     return data_.begin();
   }
 
-  std::vector<ClauseOrVariable>::const_iterator clsBegin() const {
+  std::vector<Variant<ClauseIndex,VariableIndex>>::const_iterator
+  clsBegin() const {
     return data_.begin() + clauses_ofs_;
   }
 
@@ -101,7 +103,7 @@ private:
   // variables SENTINEL clauses SENTINEL
   // this order has to be taken care of on filling
   // in the data!
-  std::vector<ClauseOrVariable> data_;
+  std::vector<Variant<ClauseIndex,VariableIndex>> data_;
   unsigned clauses_ofs_ = 0;
   // id_ will identify denote the entry in the cacheable component database,
   // where a Packed version of this component is stored

--- a/include/sharpSAT/component_types/component.h
+++ b/include/sharpSAT/component_types/component.h
@@ -81,11 +81,11 @@ public:
   void createAsDummyComponent(VariableIndex max_var_id, ClauseIndex max_clause_id) {
     data_.clear();
     clauses_ofs_ = 1;
-    for (VariableIndex idvar(1); idvar <= max_var_id; idvar++)
+    for (VariableIndex idvar(1); idvar <= max_var_id; ++idvar)
       addVar(idvar);
     closeVariableData();
     if (max_clause_id != clsSENTINEL)
-      for (ClauseIndex idcl(1); idcl <= max_clause_id; idcl++)
+      for (ClauseIndex idcl(1); idcl <= max_clause_id; ++idcl)
         addCl(idcl);
     closeClauseData();
   }

--- a/include/sharpSAT/component_types/component.h
+++ b/include/sharpSAT/component_types/component.h
@@ -35,11 +35,11 @@ public:
     // the only time a varsSENTINEL is added should be in a
     // call to closeVariableData(..)
     assert(var != varsSENTINEL);
-    data_.push_back(var);
+    data_.push_back(static_cast<unsigned>(var));
   }
 
   void closeVariableData() {
-    data_.push_back(varsSENTINEL);
+    data_.push_back(static_cast<unsigned>(varsSENTINEL));
     clauses_ofs_ = data_.size();
   }
 
@@ -47,19 +47,19 @@ public:
     // the only time a clsSENTINEL is added should be in a
     // call to closeClauseData(..)
     assert(cl != clsSENTINEL);
-    data_.push_back(cl);
+    data_.push_back(static_cast<unsigned>(cl));
   }
 
   void closeClauseData() {
-    data_.push_back(clsSENTINEL);
+    data_.push_back(static_cast<unsigned>(clsSENTINEL));
     assert(*(clsBegin()-1) == 0);
   }
 
-  std::vector<VariableIndex>::const_iterator varsBegin() const {
+  std::vector<unsigned>::const_iterator varsBegin() const {
     return data_.begin();
   }
 
-  std::vector<ClauseIndex>::const_iterator clsBegin() const {
+  std::vector<unsigned>::const_iterator clsBegin() const {
     return data_.begin() + clauses_ofs_;
   }
 
@@ -75,14 +75,14 @@ public:
     return data_.empty();
   }
 
-  void createAsDummyComponent(unsigned max_var_id, unsigned max_clause_id) {
+  void createAsDummyComponent(VariableIndex max_var_id, ClauseIndex max_clause_id) {
     data_.clear();
     clauses_ofs_ = 1;
-    for (unsigned idvar = 1; idvar <= max_var_id; idvar++)
+    for (VariableIndex idvar(1); idvar <= max_var_id; idvar++)
       addVar(idvar);
     closeVariableData();
-    if (max_clause_id > 0)
-      for (unsigned idcl = 1; idcl <= max_clause_id; idcl++)
+    if (max_clause_id != clsSENTINEL)
+      for (ClauseIndex idcl(1); idcl <= max_clause_id; idcl++)
         addCl(idcl);
     closeClauseData();
   }

--- a/include/sharpSAT/component_types/component.h
+++ b/include/sharpSAT/component_types/component.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <sharpSAT/primitive_types.h>
+#include <sharpSAT/unions.h>
 
 namespace sharpSAT {
 
@@ -35,11 +36,11 @@ public:
     // the only time a varsSENTINEL is added should be in a
     // call to closeVariableData(..)
     assert(var != varsSENTINEL);
-    data_.push_back(static_cast<unsigned>(var));
+    data_.push_back(var);
   }
 
   void closeVariableData() {
-    data_.push_back(static_cast<unsigned>(varsSENTINEL));
+    data_.push_back(varsSENTINEL);
     clauses_ofs_ = data_.size();
   }
 
@@ -47,19 +48,19 @@ public:
     // the only time a clsSENTINEL is added should be in a
     // call to closeClauseData(..)
     assert(cl != clsSENTINEL);
-    data_.push_back(static_cast<unsigned>(cl));
+    data_.push_back(cl);
   }
 
   void closeClauseData() {
-    data_.push_back(static_cast<unsigned>(clsSENTINEL));
-    assert(*(clsBegin()-1) == 0);
+    data_.push_back(clsSENTINEL);
+    assert((clsBegin() - 1)->var() == varsSENTINEL);
   }
 
-  std::vector<unsigned>::const_iterator varsBegin() const {
+  std::vector<ClauseOrVariable>::const_iterator varsBegin() const {
     return data_.begin();
   }
 
-  std::vector<unsigned>::const_iterator clsBegin() const {
+  std::vector<ClauseOrVariable>::const_iterator clsBegin() const {
     return data_.begin() + clauses_ofs_;
   }
 
@@ -100,7 +101,7 @@ private:
   // variables SENTINEL clauses SENTINEL
   // this order has to be taken care of on filling
   // in the data!
-  std::vector<unsigned> data_;
+  std::vector<ClauseOrVariable> data_;
   unsigned clauses_ofs_ = 0;
   // id_ will identify denote the entry in the cacheable component database,
   // where a Packed version of this component is stored

--- a/include/sharpSAT/component_types/component_archetype.h
+++ b/include/sharpSAT/component_types/component_archetype.h
@@ -188,21 +188,21 @@ public:
     p_new_comp->reserveSpace(stack_size, super_comp().numLongClauses());
     current_comp_for_caching_.clear();
 
-    for (auto v_it = super_comp().varsBegin(); v_it->var() != varsSENTINEL;  v_it++)
-      if (var_seen(v_it->var())) { //we have to put a var into our component
-        p_new_comp->addVar(v_it->var());
-        current_comp_for_caching_.addVar(v_it->var());
-        setVar_in_other_comp(v_it->var());
+    for (auto v_it = super_comp().varsBegin(); v_it->get<VariableIndex>() != varsSENTINEL;  v_it++)
+      if (var_seen(v_it->get<VariableIndex>())) { //we have to put a var into our component
+        p_new_comp->addVar(v_it->get<VariableIndex>());
+        current_comp_for_caching_.addVar(v_it->get<VariableIndex>());
+        setVar_in_other_comp(v_it->get<VariableIndex>());
       }
     p_new_comp->closeVariableData();
     current_comp_for_caching_.closeVariableData();
 
-    for (auto it_cl = super_comp().clsBegin(); it_cl->cls() != clsSENTINEL; it_cl++)
-      if (clause_seen(it_cl->cls())) {
-        p_new_comp->addCl(it_cl->cls());
-           if(!clause_all_lits_active(it_cl->cls()))
-             current_comp_for_caching_.addCl(it_cl->cls());
-        setClause_in_other_comp(it_cl->cls());
+    for (auto it_cl = super_comp().clsBegin(); it_cl->get<ClauseIndex>() != clsSENTINEL; it_cl++)
+      if (clause_seen(it_cl->get<ClauseIndex>())) {
+        p_new_comp->addCl(it_cl->get<ClauseIndex>());
+           if(!clause_all_lits_active(it_cl->get<ClauseIndex>()))
+             current_comp_for_caching_.addCl(it_cl->get<ClauseIndex>());
+        setClause_in_other_comp(it_cl->get<ClauseIndex>());
       }
     p_new_comp->closeClauseData();
     current_comp_for_caching_.closeClauseData();

--- a/include/sharpSAT/component_types/component_archetype.h
+++ b/include/sharpSAT/component_types/component_archetype.h
@@ -188,21 +188,21 @@ public:
     p_new_comp->reserveSpace(stack_size, super_comp().numLongClauses());
     current_comp_for_caching_.clear();
 
-    for (auto v_it = super_comp().varsBegin(); VariableIndex(*v_it) != varsSENTINEL;  v_it++)
-      if (var_seen(VariableIndex(*v_it))) { //we have to put a var into our component
-        p_new_comp->addVar(VariableIndex(*v_it));
-        current_comp_for_caching_.addVar(VariableIndex(*v_it));
-        setVar_in_other_comp(VariableIndex(*v_it));
+    for (auto v_it = super_comp().varsBegin(); v_it->var() != varsSENTINEL;  v_it++)
+      if (var_seen(v_it->var())) { //we have to put a var into our component
+        p_new_comp->addVar(v_it->var());
+        current_comp_for_caching_.addVar(v_it->var());
+        setVar_in_other_comp(v_it->var());
       }
     p_new_comp->closeVariableData();
     current_comp_for_caching_.closeVariableData();
 
-    for (auto it_cl = super_comp().clsBegin(); ClauseIndex(*it_cl) != clsSENTINEL; it_cl++)
-      if (clause_seen(ClauseIndex(*it_cl))) {
-        p_new_comp->addCl(ClauseIndex(*it_cl));
-           if(!clause_all_lits_active(ClauseIndex(*it_cl)))
-             current_comp_for_caching_.addCl(ClauseIndex(*it_cl));
-        setClause_in_other_comp(ClauseIndex(*it_cl));
+    for (auto it_cl = super_comp().clsBegin(); it_cl->cls() != clsSENTINEL; it_cl++)
+      if (clause_seen(it_cl->cls())) {
+        p_new_comp->addCl(it_cl->cls());
+           if(!clause_all_lits_active(it_cl->cls()))
+             current_comp_for_caching_.addCl(it_cl->cls());
+        setClause_in_other_comp(it_cl->cls());
       }
     p_new_comp->closeClauseData();
     current_comp_for_caching_.closeClauseData();

--- a/include/sharpSAT/component_types/difference_packed_component.h
+++ b/include/sharpSAT/component_types/difference_packed_component.h
@@ -77,9 +77,9 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
 
   unsigned max_var_diff = 0;
   unsigned hashkey_vars = static_cast<unsigned>(*rComp.varsBegin());
-  for (auto it = rComp.varsBegin() + 1; it->var() != varsSENTINEL; it++) {
-    auto star_it = static_cast<unsigned>(it->var());
-    auto star_it_minus_one = static_cast<unsigned>((it - 1)->var());
+  for (auto it = rComp.varsBegin() + 1; it->get<VariableIndex>() != varsSENTINEL; it++) {
+    auto star_it = static_cast<unsigned>(it->get<VariableIndex>());
+    auto star_it_minus_one = static_cast<unsigned>((it - 1)->get<VariableIndex>());
 
     hashkey_vars = (hashkey_vars * 3) + star_it;
     if ((star_it - star_it_minus_one) - 1 > max_var_diff)
@@ -88,10 +88,10 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
 
   unsigned hashkey_clauses = static_cast<unsigned>(*rComp.clsBegin());
   unsigned max_clause_diff = 0;
-  if (rComp.clsBegin()->cls() != clsSENTINEL) {
-    for (auto jt = rComp.clsBegin() + 1; jt->cls() != clsSENTINEL; jt++) {
-      auto star_jt = static_cast<unsigned>(jt->cls());
-      auto star_jt_minus_one = static_cast<unsigned>((jt - 1)->cls());
+  if (rComp.clsBegin()->get<ClauseIndex>() != clsSENTINEL) {
+    for (auto jt = rComp.clsBegin() + 1; jt->get<ClauseIndex>() != clsSENTINEL; jt++) {
+      auto star_jt = static_cast<unsigned>(jt->get<ClauseIndex>());
+      auto star_jt_minus_one = static_cast<unsigned>((jt - 1)->get<ClauseIndex>());
 
       hashkey_clauses = hashkey_clauses*3 + static_cast<unsigned>(*jt);
       if (star_jt - star_jt_minus_one - 1 > max_clause_diff)
@@ -113,7 +113,7 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
   data_size_vars += (rComp.num_variables() - 1) * bits_per_var_diff ;
 
   unsigned data_size_clauses = 0;
-  if (rComp.clsBegin()->cls() != clsSENTINEL)
+  if (rComp.clsBegin()->get<ClauseIndex>() != clsSENTINEL)
     data_size_clauses += bits_per_clause() + 5
        + (rComp.numLongClauses() - 1) * bits_per_clause_diff;
 
@@ -130,21 +130,21 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
   bs.stuff(static_cast<unsigned>(*rComp.varsBegin()), bits_per_variable());
 
   if(bits_per_var_diff)
-  for (auto it = rComp.varsBegin() + 1; it->var() != varsSENTINEL; it++) {
-    auto star_it = static_cast<unsigned>(it->var());
-    auto star_it_minus_one = static_cast<unsigned>((it - 1)->var());
+  for (auto it = rComp.varsBegin() + 1; it->get<VariableIndex>() != varsSENTINEL; it++) {
+    auto star_it = static_cast<unsigned>(it->get<VariableIndex>());
+    auto star_it_minus_one = static_cast<unsigned>((it - 1)->get<VariableIndex>());
 
     bs.stuff(star_it - star_it_minus_one - 1, bits_per_var_diff);
   }
 
 
-  if (rComp.clsBegin()->cls() != clsSENTINEL) {
+  if (rComp.clsBegin()->get<ClauseIndex>() != clsSENTINEL) {
     bs.stuff(bits_per_clause_diff, 5);
     bs.stuff(static_cast<unsigned>(*rComp.clsBegin()), bits_per_clause());
     if(bits_per_clause_diff)
-     for (auto jt = rComp.clsBegin() + 1; jt->cls() != clsSENTINEL; jt++) {
-      auto star_jt = static_cast<unsigned>(jt->cls());
-      auto star_jt_minus_one = static_cast<unsigned>((jt - 1)->cls());
+     for (auto jt = rComp.clsBegin() + 1; jt->get<ClauseIndex>() != clsSENTINEL; jt++) {
+      auto star_jt = static_cast<unsigned>(jt->get<ClauseIndex>());
+      auto star_jt_minus_one = static_cast<unsigned>((jt - 1)->get<ClauseIndex>());
       bs.stuff(star_jt - star_jt_minus_one - 1, bits_per_clause_diff);
      }
   }

--- a/include/sharpSAT/component_types/difference_packed_component.h
+++ b/include/sharpSAT/component_types/difference_packed_component.h
@@ -76,20 +76,26 @@ private:
 DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
 
   unsigned max_var_diff = 0;
-  unsigned hashkey_vars = *rComp.varsBegin();
-  for (auto it = rComp.varsBegin() + 1; VariableIndex(*it) != varsSENTINEL; it++) {
-    hashkey_vars = (hashkey_vars * 3) + *it;
-    if ((*it - *(it - 1)) - 1 > max_var_diff)
-      max_var_diff = (*it - *(it - 1)) - 1 ;
+  unsigned hashkey_vars = static_cast<unsigned>(*rComp.varsBegin());
+  for (auto it = rComp.varsBegin() + 1; it->var() != varsSENTINEL; it++) {
+    auto star_it = static_cast<unsigned>(it->var());
+    auto star_it_minus_one = static_cast<unsigned>((it - 1)->var());
+
+    hashkey_vars = (hashkey_vars * 3) + star_it;
+    if ((star_it - star_it_minus_one) - 1 > max_var_diff)
+      max_var_diff = (star_it - star_it_minus_one) - 1;
   }
 
-  unsigned hashkey_clauses = *rComp.clsBegin();
+  unsigned hashkey_clauses = static_cast<unsigned>(*rComp.clsBegin());
   unsigned max_clause_diff = 0;
-  if (*rComp.clsBegin()) {
-    for (auto jt = rComp.clsBegin() + 1; ClauseIndex(*jt) != clsSENTINEL; jt++) {
-      hashkey_clauses = hashkey_clauses*3 + *jt;
-      if (*jt - *(jt - 1) - 1 > max_clause_diff)
-        max_clause_diff = *jt - *(jt - 1) - 1;
+  if (rComp.clsBegin()->cls() != clsSENTINEL) {
+    for (auto jt = rComp.clsBegin() + 1; jt->cls() != clsSENTINEL; jt++) {
+      auto star_jt = static_cast<unsigned>(jt->cls());
+      auto star_jt_minus_one = static_cast<unsigned>((jt - 1)->cls());
+
+      hashkey_clauses = hashkey_clauses*3 + static_cast<unsigned>(*jt);
+      if (star_jt - star_jt_minus_one - 1 > max_clause_diff)
+        max_clause_diff = star_jt - star_jt_minus_one - 1;
     }
   }
 
@@ -107,7 +113,7 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
   data_size_vars += (rComp.num_variables() - 1) * bits_per_var_diff ;
 
   unsigned data_size_clauses = 0;
-  if(*rComp.clsBegin())
+  if (rComp.clsBegin()->cls() != clsSENTINEL)
     data_size_clauses += bits_per_clause() + 5
        + (rComp.numLongClauses() - 1) * bits_per_clause_diff;
 
@@ -121,19 +127,26 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
   bs.stuff(data_size, bits_of_data_size());
   bs.stuff(rComp.num_variables(), bits_per_variable());
   bs.stuff(bits_per_var_diff, 5);
-  bs.stuff(*rComp.varsBegin(), bits_per_variable());
+  bs.stuff(static_cast<unsigned>(*rComp.varsBegin()), bits_per_variable());
 
   if(bits_per_var_diff)
-  for (auto it = rComp.varsBegin() + 1; VariableIndex(*it) != varsSENTINEL; it++)
-    bs.stuff(*it - *(it - 1) - 1, bits_per_var_diff);
+  for (auto it = rComp.varsBegin() + 1; it->var() != varsSENTINEL; it++) {
+    auto star_it = static_cast<unsigned>(it->var());
+    auto star_it_minus_one = static_cast<unsigned>((it - 1)->var());
+
+    bs.stuff(star_it - star_it_minus_one - 1, bits_per_var_diff);
+  }
 
 
-  if (*rComp.clsBegin()) {
+  if (rComp.clsBegin()->cls() != clsSENTINEL) {
     bs.stuff(bits_per_clause_diff, 5);
-    bs.stuff(*rComp.clsBegin(), bits_per_clause());
+    bs.stuff(static_cast<unsigned>(*rComp.clsBegin()), bits_per_clause());
     if(bits_per_clause_diff)
-     for (auto jt = rComp.clsBegin() + 1; ClauseIndex(*jt) != clsSENTINEL; jt++)
-      bs.stuff(*jt - *(jt - 1) - 1, bits_per_clause_diff);
+     for (auto jt = rComp.clsBegin() + 1; jt->cls() != clsSENTINEL; jt++) {
+      auto star_jt = static_cast<unsigned>(jt->cls());
+      auto star_jt_minus_one = static_cast<unsigned>((jt - 1)->cls());
+      bs.stuff(star_jt - star_jt_minus_one - 1, bits_per_clause_diff);
+     }
   }
 
   // to check wheter the "END" block of bits_per_clause()

--- a/include/sharpSAT/component_types/difference_packed_component.h
+++ b/include/sharpSAT/component_types/difference_packed_component.h
@@ -77,7 +77,7 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
 
   unsigned max_var_diff = 0;
   unsigned hashkey_vars = *rComp.varsBegin();
-  for (auto it = rComp.varsBegin() + 1; *it != varsSENTINEL; it++) {
+  for (auto it = rComp.varsBegin() + 1; VariableIndex(*it) != varsSENTINEL; it++) {
     hashkey_vars = (hashkey_vars * 3) + *it;
     if ((*it - *(it - 1)) - 1 > max_var_diff)
       max_var_diff = (*it - *(it - 1)) - 1 ;
@@ -86,7 +86,7 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
   unsigned hashkey_clauses = *rComp.clsBegin();
   unsigned max_clause_diff = 0;
   if (*rComp.clsBegin()) {
-    for (auto jt = rComp.clsBegin() + 1; *jt != clsSENTINEL; jt++) {
+    for (auto jt = rComp.clsBegin() + 1; ClauseIndex(*jt) != clsSENTINEL; jt++) {
       hashkey_clauses = hashkey_clauses*3 + *jt;
       if (*jt - *(jt - 1) - 1 > max_clause_diff)
         max_clause_diff = *jt - *(jt - 1) - 1;
@@ -124,7 +124,7 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
   bs.stuff(*rComp.varsBegin(), bits_per_variable());
 
   if(bits_per_var_diff)
-  for (auto it = rComp.varsBegin() + 1; *it != varsSENTINEL; it++)
+  for (auto it = rComp.varsBegin() + 1; VariableIndex(*it) != varsSENTINEL; it++)
     bs.stuff(*it - *(it - 1) - 1, bits_per_var_diff);
 
 
@@ -132,7 +132,7 @@ DifferencePackedComponent::DifferencePackedComponent(Component &rComp) {
     bs.stuff(bits_per_clause_diff, 5);
     bs.stuff(*rComp.clsBegin(), bits_per_clause());
     if(bits_per_clause_diff)
-     for (auto jt = rComp.clsBegin() + 1; *jt != clsSENTINEL; jt++)
+     for (auto jt = rComp.clsBegin() + 1; ClauseIndex(*jt) != clsSENTINEL; jt++)
       bs.stuff(*jt - *(jt - 1) - 1, bits_per_clause_diff);
   }
 

--- a/include/sharpSAT/containers.h
+++ b/include/sharpSAT/containers.h
@@ -24,11 +24,11 @@ public:
 			std::vector<_T>(size * 2, __value) {
 	}
 	inline _T &operator[](const LiteralID lit) {
-		return *(std::vector<_T>::begin() + lit.raw());
+		return *(std::vector<_T>::begin() + static_cast<unsigned>(lit));
 	}
 
 	inline const _T &operator[](const LiteralID &lit) const {
-		return *(std::vector<_T>::begin() + lit.raw());
+		return *(std::vector<_T>::begin() + static_cast<unsigned>(lit));
 	}
 
 	inline typename std::vector<_T>::iterator begin() {
@@ -82,8 +82,5 @@ struct VariableIndexedVector : public std::vector<T> {
     return std::vector<T>::operator[](static_cast<unsigned>(var));
   }
 }; // var_vactor<T>
-
-
-
 } // sharpSAT namespace
 #endif /* CONTAINERS_H_ */

--- a/include/sharpSAT/containers.h
+++ b/include/sharpSAT/containers.h
@@ -47,7 +47,7 @@ public:
 	}
 
 	LiteralID end_lit() {
-		return LiteralID(size() / 2, false);
+		return LiteralID(VariableIndex(size() / 2), false);
 	}
 
 	using std::vector<_T>::end;
@@ -55,5 +55,35 @@ public:
 	using std::vector<_T>::clear;
 	using std::vector<_T>::push_back;
 }; // LiteralIndexedVector
+
+
+
+//! Vector indexed by \ref VariableIndex
+template<class T>
+struct VariableIndexedVector : public std::vector<T> {
+
+  VariableIndexedVector()
+  : std::vector<T>()
+  {}
+
+  VariableIndexedVector(size_t n)
+  : std::vector<T>(n)
+  {}
+
+  VariableIndexedVector(size_t n, const T& value)
+  : std::vector<T>(n, value)
+  {}
+
+  typename std::vector<T>::const_reference operator [](const VariableIndex& var) const {
+    return std::vector<T>::operator[](static_cast<unsigned>(var));
+  }
+
+  typename std::vector<T>::reference operator [](const VariableIndex& var) {
+    return std::vector<T>::operator[](static_cast<unsigned>(var));
+  }
+}; // var_vactor<T>
+
+
+
 } // sharpSAT namespace
 #endif /* CONTAINERS_H_ */

--- a/include/sharpSAT/new_component_analyzer.h
+++ b/include/sharpSAT/new_component_analyzer.h
@@ -71,14 +71,14 @@ public:
   void setupAnalysisContext(StackLevel &top, Component & super_comp){
      archetype_.reInitialize(top,super_comp);
 
-     for (auto vt = super_comp.varsBegin(); VariableIndex(*vt) != varsSENTINEL; vt++)
-       if (isActive(VariableIndex(*vt))) {
-         archetype_.setVar_in_sup_comp_unseen(VariableIndex(*vt));
-         var_frequency_scores_[VariableIndex(*vt)] = 0;
+     for (auto vt = super_comp.varsBegin(); vt->var() != varsSENTINEL; vt++)
+       if (isActive(vt->var())) {
+         archetype_.setVar_in_sup_comp_unseen(vt->var());
+         var_frequency_scores_[vt->var()] = 0;
        }
 
-     for (auto itCl = super_comp.clsBegin(); ClauseIndex(*itCl) != clsSENTINEL; itCl++)
-         archetype_.setClause_in_sup_comp_unseen(ClauseIndex(*itCl));
+     for (auto itCl = super_comp.clsBegin(); itCl->cls() != clsSENTINEL; itCl++)
+         archetype_.setClause_in_sup_comp_unseen(itCl->cls());
   }
 
   // returns true, iff the component found is non-trivial
@@ -145,7 +145,7 @@ private:
   // this should give better cache behaviour,
   // because all links of one variable (binary and nonbinray) are found
   // in one contiguous chunk of memory
-  std::vector<unsigned> unified_variable_links_lists_pool_;
+  std::vector<ClauseOrLiteralOrVariable> unified_variable_links_lists_pool_;
 
   std::vector<ClauseOfs> map_clause_id_to_ofs_;
   VariableIndexedVector<unsigned> variable_link_list_offsets_;
@@ -189,7 +189,7 @@ private:
       static_cast<unsigned>(cl_ofs) - CAClauseHeader::overheadInLits()]);
   }
 
-  std::vector<unsigned>::iterator beginOfLinkList(VariableIndex v) {
+  std::vector<ClauseOrLiteralOrVariable>::iterator beginOfLinkList(VariableIndex v) {
     return unified_variable_links_lists_pool_.begin() + variable_link_list_offsets_[v];
   }
 
@@ -204,16 +204,16 @@ private:
   // after execution component_search_stack.size()==1
   void recordComponentOf(const VariableIndex var);
 
-  void pushLitsInto(std::vector<unsigned> &target,
+  void pushLitsInto(std::vector<ClauseOrLiteral> &target,
 		       const std::vector<LiteralID> &lit_pool,
 		       unsigned start_of_cl,
 		       LiteralID & omitLit){
 	  for (auto it_lit = lit_pool.begin() + start_of_cl;
 			  (*it_lit != SENTINEL_LIT); it_lit++) {
 		  if(it_lit->var() != omitLit.var())
-			  target.push_back(it_lit->raw());
+			  target.push_back(*it_lit);
 	  }
-	  target.push_back(SENTINEL_LIT.raw());
+	  target.push_back(SENTINEL_LIT);
   }
 
 };

--- a/include/sharpSAT/new_component_analyzer.h
+++ b/include/sharpSAT/new_component_analyzer.h
@@ -189,8 +189,8 @@ private:
       static_cast<unsigned>(cl_ofs) - CAClauseHeader::overheadInLits()]);
   }
 
-  unsigned *beginOfLinkList(VariableIndex v) {
-    return &unified_variable_links_lists_pool_[variable_link_list_offsets_[v]];
+  std::vector<unsigned>::iterator beginOfLinkList(VariableIndex v) {
+    return unified_variable_links_lists_pool_.begin() + variable_link_list_offsets_[v];
   }
 
   std::vector<LiteralID>::iterator beginOfClause(ClauseOfs cl_ofs) {

--- a/include/sharpSAT/new_component_analyzer.h
+++ b/include/sharpSAT/new_component_analyzer.h
@@ -25,7 +25,7 @@
 namespace sharpSAT {
 
 struct CAClauseHeader {
-  unsigned clause_id = 0;
+  ClauseIndex clause_id = ClauseIndex(0);
   LiteralID lit_A;
   LiteralID lit_B;
 
@@ -71,14 +71,14 @@ public:
   void setupAnalysisContext(StackLevel &top, Component & super_comp){
      archetype_.reInitialize(top,super_comp);
 
-     for (auto vt = super_comp.varsBegin(); *vt != varsSENTINEL; vt++)
-       if (isActive(*vt)) {
-         archetype_.setVar_in_sup_comp_unseen(*vt);
-         var_frequency_scores_[*vt] = 0;
+     for (auto vt = super_comp.varsBegin(); VariableIndex(*vt) != varsSENTINEL; vt++)
+       if (isActive(VariableIndex(*vt))) {
+         archetype_.setVar_in_sup_comp_unseen(VariableIndex(*vt));
+         var_frequency_scores_[VariableIndex(*vt)] = 0;
        }
 
-     for (auto itCl = super_comp.clsBegin(); *itCl != clsSENTINEL; itCl++)
-         archetype_.setClause_in_sup_comp_unseen(*itCl);
+     for (auto itCl = super_comp.clsBegin(); ClauseIndex(*itCl) != clsSENTINEL; itCl++)
+         archetype_.setClause_in_sup_comp_unseen(ClauseIndex(*itCl));
   }
 
   // returns true, iff the component found is non-trivial
@@ -99,10 +99,11 @@ public:
     return archetype_.makeComponentFromState(search_stack_.size());
   }
 
-  unsigned max_clause_id(){
+  ClauseIndex max_clause_id(){
      return max_clause_id_;
   }
-  unsigned max_variable_id(){
+
+  VariableIndex max_variable_id(){
     return max_variable_id_;
   }
 
@@ -112,9 +113,9 @@ public:
 
   //begin DEBUG
   void test_checkArchetypeRepForClause(unsigned *pcl_ofs){
-      ClauseIndex clID = getClauseID(*pcl_ofs);
+      ClauseIndex clID = getClauseID(ClauseOfs(*pcl_ofs));
       bool all_a = true;
-      for (auto itL = beginOfClause(*pcl_ofs); *itL != SENTINEL_LIT; itL++) {
+      for (auto itL = beginOfClause(ClauseOfs(*pcl_ofs)); *itL != SENTINEL_LIT; itL++) {
         if(!isActive(*itL))
           all_a = false;
       }
@@ -126,8 +127,8 @@ private:
   // the id of the last clause
   // note that clause ID is the clause number,
   // different from the offset of the clause in the literal pool
-  unsigned max_clause_id_ = 0;
-  unsigned max_variable_id_ = 0;
+  ClauseIndex max_clause_id_ = ClauseIndex(0);
+  VariableIndex max_variable_id_ = VariableIndex(0);
 
   // pool of clauses as lists of LiteralIDs
   // Note that with a clause begin position p we have
@@ -146,11 +147,11 @@ private:
   // in one contiguous chunk of memory
   std::vector<unsigned> unified_variable_links_lists_pool_;
 
-  std::vector<unsigned> map_clause_id_to_ofs_;
-  std::vector<unsigned> variable_link_list_offsets_;
+  std::vector<ClauseOfs> map_clause_id_to_ofs_;
+  VariableIndexedVector<unsigned> variable_link_list_offsets_;
   LiteralIndexedVector<TriValue> & literal_values_;
 
-  std::vector<unsigned> var_frequency_scores_;
+  VariableIndexedVector<unsigned> var_frequency_scores_;
 
   ComponentArchetype  archetype_;
 
@@ -175,14 +176,17 @@ private:
     return literal_values_[LiteralID(v, true)] == TriValue::X_TRI;
   }
 
-  unsigned getClauseID(ClauseOfs cl_ofs) {
-    return reinterpret_cast<CAClauseHeader *>(&literal_pool_[cl_ofs
-        - CAClauseHeader::overheadInLits()])->clause_id;
+  ClauseIndex getClauseID(ClauseOfs cl_ofs) {
+    return ClauseIndex(
+     reinterpret_cast<CAClauseHeader *>(&literal_pool_[
+       static_cast<unsigned>(cl_ofs) - CAClauseHeader::overheadInLits()
+      ])->clause_id
+    );
   }
 
   CAClauseHeader &getHeaderOf(ClauseOfs cl_ofs) {
-    return *reinterpret_cast<CAClauseHeader *>(&literal_pool_[cl_ofs
-        - CAClauseHeader::overheadInLits()]);
+    return *reinterpret_cast<CAClauseHeader *>(&literal_pool_[
+      static_cast<unsigned>(cl_ofs) - CAClauseHeader::overheadInLits()]);
   }
 
   unsigned *beginOfLinkList(VariableIndex v) {
@@ -190,7 +194,7 @@ private:
   }
 
   std::vector<LiteralID>::iterator beginOfClause(ClauseOfs cl_ofs) {
-    return literal_pool_.begin() + cl_ofs;
+    return literal_pool_.begin() + static_cast<unsigned>(cl_ofs);
   }
 
   // stores all information about the component of var

--- a/include/sharpSAT/new_component_analyzer.h
+++ b/include/sharpSAT/new_component_analyzer.h
@@ -71,14 +71,14 @@ public:
   void setupAnalysisContext(StackLevel &top, Component & super_comp){
      archetype_.reInitialize(top,super_comp);
 
-     for (auto vt = super_comp.varsBegin(); vt->var() != varsSENTINEL; vt++)
-       if (isActive(vt->var())) {
-         archetype_.setVar_in_sup_comp_unseen(vt->var());
-         var_frequency_scores_[vt->var()] = 0;
+     for (auto vt = super_comp.varsBegin(); vt->get<VariableIndex>() != varsSENTINEL; vt++)
+       if (isActive(vt->get<VariableIndex>())) {
+         archetype_.setVar_in_sup_comp_unseen(vt->get<VariableIndex>());
+         var_frequency_scores_[vt->get<VariableIndex>()] = 0;
        }
 
-     for (auto itCl = super_comp.clsBegin(); itCl->cls() != clsSENTINEL; itCl++)
-         archetype_.setClause_in_sup_comp_unseen(itCl->cls());
+     for (auto itCl = super_comp.clsBegin(); itCl->get<ClauseIndex>() != clsSENTINEL; itCl++)
+         archetype_.setClause_in_sup_comp_unseen(itCl->get<ClauseIndex>());
   }
 
   // returns true, iff the component found is non-trivial
@@ -145,7 +145,7 @@ private:
   // this should give better cache behaviour,
   // because all links of one variable (binary and nonbinray) are found
   // in one contiguous chunk of memory
-  std::vector<ClauseOrLiteralOrVariable> unified_variable_links_lists_pool_;
+  std::vector<Variant<ClauseIndex,LiteralID,VariableIndex,unsigned>> unified_variable_links_lists_pool_;
 
   std::vector<ClauseOfs> map_clause_id_to_ofs_;
   VariableIndexedVector<unsigned> variable_link_list_offsets_;
@@ -189,7 +189,7 @@ private:
       static_cast<unsigned>(cl_ofs) - CAClauseHeader::overheadInLits()]);
   }
 
-  std::vector<ClauseOrLiteralOrVariable>::iterator beginOfLinkList(VariableIndex v) {
+  std::vector<Variant<ClauseIndex,LiteralID,VariableIndex,unsigned>>::iterator beginOfLinkList(VariableIndex v) {
     return unified_variable_links_lists_pool_.begin() + variable_link_list_offsets_[v];
   }
 
@@ -204,7 +204,7 @@ private:
   // after execution component_search_stack.size()==1
   void recordComponentOf(const VariableIndex var);
 
-  void pushLitsInto(std::vector<ClauseOrLiteral> &target,
+  void pushLitsInto(std::vector<Variant<ClauseIndex,LiteralID>> &target,
 		       const std::vector<LiteralID> &lit_pool,
 		       unsigned start_of_cl,
 		       LiteralID & omitLit){

--- a/include/sharpSAT/primitive_types.h
+++ b/include/sharpSAT/primitive_types.h
@@ -8,20 +8,176 @@
 #ifndef SHARP_SAT_PRIMITIVE_TYPES_H_
 #define SHARP_SAT_PRIMITIVE_TYPES_H_
 
+#include <limits>
+#include <cassert>
+
 namespace sharpSAT {
 
-typedef unsigned VariableIndex;
+struct VariableIndex {
+  unsigned var_id_;
 
-typedef unsigned ClauseIndex;
+public:
+  VariableIndex() : var_id_(0) {}
+  explicit VariableIndex(unsigned var_id) : var_id_(var_id) {}
+
+  explicit operator unsigned() const { return var_id_; }
+
+  bool operator ==(const VariableIndex& rhs) const
+  { return var_id_ == rhs.var_id_; }
+
+  bool operator !=(const VariableIndex& rhs) const
+  { return var_id_ != rhs.var_id_; }
+
+  bool operator <(const VariableIndex& rhs) const
+  { return var_id_ < rhs.var_id_; }
+
+  bool operator >(const VariableIndex& rhs) const
+  { return var_id_ > rhs.var_id_; }
+
+  bool operator <=(const VariableIndex& rhs) const
+  { return var_id_ <= rhs.var_id_; }
+
+  bool operator >=(const VariableIndex& rhs) const
+  { return var_id_ >= rhs.var_id_; }
+
+  VariableIndex& operator ++() {
+    ++var_id_;
+    return *this;
+  }
+
+  VariableIndex operator ++(int) {
+    auto before = *this;
+    ++var_id_;
+    return before;
+  }
+
+  VariableIndex& operator --() {
+    --var_id_;
+    return *this;
+  }
+
+  VariableIndex operator --(int) {
+    auto before = *this;
+    --var_id_;
+    return before;
+  }
+};
+
+static const VariableIndex varsSENTINEL(0);
+
+
+
+struct ClauseIndex {
+  unsigned clause_index_;
+
+public:
+  ClauseIndex() : clause_index_(0) {}
+  explicit ClauseIndex(unsigned var_id) : clause_index_(var_id) {}
+
+  explicit operator unsigned() const { return clause_index_; }
+
+  bool operator ==(const ClauseIndex& rhs) const
+  { return clause_index_ == rhs.clause_index_; }
+
+  bool operator !=(const ClauseIndex& rhs) const
+  { return clause_index_ != rhs.clause_index_; }
+
+  bool operator <(const ClauseIndex& rhs) const
+  { return clause_index_ < rhs.clause_index_; }
+
+  bool operator >(const ClauseIndex& rhs) const
+  { return clause_index_ > rhs.clause_index_; }
+
+  bool operator <=(const ClauseIndex& rhs) const
+  { return clause_index_ <= rhs.clause_index_; }
+
+  bool operator >=(const ClauseIndex& rhs) const
+  { return clause_index_ >= rhs.clause_index_; }
+
+  ClauseIndex& operator ++() {
+    ++clause_index_;
+    return *this;
+  }
+
+  ClauseIndex operator ++(int) {
+    auto before = *this;
+    ++clause_index_;
+    return before;
+  }
+
+  ClauseIndex& operator --() {
+    --clause_index_;
+    return *this;
+  }
+
+  ClauseIndex operator --(int) {
+    auto before = *this;
+    --clause_index_;
+    return before;
+  }
+};
+
 static const ClauseIndex clsSENTINEL(0);
 
-typedef unsigned ClauseOfs; //!< Offset of a clause
+
+
+//!< Offset of a clause
+struct ClauseOfs {
+  unsigned clause_ofs_;
+
+public:
+  ClauseOfs() : clause_ofs_(0) {}
+  explicit ClauseOfs(unsigned var_id) : clause_ofs_(var_id) {}
+
+  explicit operator unsigned() const { return clause_ofs_; }
+
+  bool operator ==(const ClauseOfs& rhs) const
+  { return clause_ofs_ == rhs.clause_ofs_; }
+
+  bool operator !=(const ClauseOfs& rhs) const
+  { return clause_ofs_ != rhs.clause_ofs_; }
+
+  bool operator <(const ClauseOfs& rhs) const
+  { return clause_ofs_ < rhs.clause_ofs_; }
+
+  bool operator >(const ClauseOfs& rhs) const
+  { return clause_ofs_ > rhs.clause_ofs_; }
+
+  bool operator <=(const ClauseOfs& rhs) const
+  { return clause_ofs_ <= rhs.clause_ofs_; }
+
+  bool operator >=(const ClauseOfs& rhs) const
+  { return clause_ofs_ >= rhs.clause_ofs_; }
+
+  ClauseOfs& operator ++() {
+    ++clause_ofs_;
+    return *this;
+  }
+
+  ClauseOfs operator ++(int) {
+    auto before = *this;
+    ++clause_ofs_;
+    return before;
+  }
+
+  ClauseOfs& operator --() {
+    --clause_ofs_;
+    return *this;
+  }
+
+  ClauseOfs operator --(int) {
+    auto before = *this;
+    --clause_ofs_;
+    return before;
+  }
+};
+
 static const ClauseOfs NOT_A_CLAUSE(0);
 static const ClauseOfs SENTINEL_CL(0);
 
-typedef unsigned CacheEntryID;
 
-static const VariableIndex varsSENTINEL = 0;
+
+typedef unsigned CacheEntryID;
 
 enum class SOLVER_StateT {
 

--- a/include/sharpSAT/primitive_types.h
+++ b/include/sharpSAT/primitive_types.h
@@ -94,6 +94,14 @@ public:
   bool operator >=(const ClauseIndex& rhs) const
   { return clause_index_ >= rhs.clause_index_; }
 
+  ClauseIndex operator +(const ClauseIndex& rhs) const {
+    return ClauseIndex(clause_index_ + rhs.clause_index_);
+  }
+
+  ClauseIndex operator -(const ClauseIndex& rhs) const {
+    return ClauseIndex(clause_index_ - rhs.clause_index_);
+  }
+
   ClauseIndex& operator ++() {
     ++clause_index_;
     return *this;

--- a/include/sharpSAT/solver.h
+++ b/include/sharpSAT/solver.h
@@ -86,9 +86,9 @@ private:
 
 
 	 void decayActivitiesOf(Component & comp) {
-	   for (auto it = comp.varsBegin(); it->var() != varsSENTINEL; it++) {
-	          literal(LiteralID(it->var(), true)).activity_score_ *=0.5;
-	          literal(LiteralID(it->var(), false)).activity_score_ *=0.5;
+	   for (auto it = comp.varsBegin(); it->get<VariableIndex>() != varsSENTINEL; it++) {
+	          literal(LiteralID(it->get<VariableIndex>(), true)).activity_score_ *=0.5;
+	          literal(LiteralID(it->get<VariableIndex>(), false)).activity_score_ *=0.5;
 	       }
 	}
 	///  this method performs Failed literal tests online

--- a/include/sharpSAT/solver.h
+++ b/include/sharpSAT/solver.h
@@ -86,9 +86,9 @@ private:
 
 
 	 void decayActivitiesOf(Component & comp) {
-	   for (auto it = comp.varsBegin(); *it != varsSENTINEL; it++) {
-	          literal(LiteralID(*it,true)).activity_score_ *=0.5;
-	          literal(LiteralID(*it,false)).activity_score_ *=0.5;
+	   for (auto it = comp.varsBegin(); VariableIndex(*it) != varsSENTINEL; it++) {
+	          literal(LiteralID(VariableIndex(*it),true)).activity_score_ *=0.5;
+	          literal(LiteralID(VariableIndex(*it),false)).activity_score_ *=0.5;
 	       }
 	}
 	///  this method performs Failed literal tests online
@@ -232,7 +232,8 @@ private:
 	void recordAllUIPCauses();
 
 	void minimizeAndStoreUIPClause(LiteralID uipLit,
-			std::vector<LiteralID> & tmp_clause, std::vector<bool> const& seen);
+			std::vector<LiteralID> & tmp_clause,
+			const VariableIndexedVector<bool>& seen);
 	void storeUIPClause(LiteralID uipLit, std::vector<LiteralID> & tmp_clause);
 	int getAssertionLevel() const {
 		return assertion_level_;

--- a/include/sharpSAT/solver.h
+++ b/include/sharpSAT/solver.h
@@ -86,9 +86,9 @@ private:
 
 
 	 void decayActivitiesOf(Component & comp) {
-	   for (auto it = comp.varsBegin(); VariableIndex(*it) != varsSENTINEL; it++) {
-	          literal(LiteralID(VariableIndex(*it),true)).activity_score_ *=0.5;
-	          literal(LiteralID(VariableIndex(*it),false)).activity_score_ *=0.5;
+	   for (auto it = comp.varsBegin(); it->var() != varsSENTINEL; it++) {
+	          literal(LiteralID(it->var(), true)).activity_score_ *=0.5;
+	          literal(LiteralID(it->var(), false)).activity_score_ *=0.5;
 	       }
 	}
 	///  this method performs Failed literal tests online

--- a/include/sharpSAT/structures.h
+++ b/include/sharpSAT/structures.h
@@ -35,6 +35,10 @@ public:
     value_ = (std::abs(lit) << 1) + (unsigned) (lit > 0);
   }
 
+  explicit LiteralID(unsigned value)
+  : value_(value)
+  {}
+
   explicit LiteralID(VariableIndex var, bool sign) {
     value_ = (static_cast<unsigned>(var) << 1) + (unsigned) sign;
   }
@@ -48,10 +52,6 @@ public:
   }
 
   void inc(){++value_;}
-
-  void copyRaw(unsigned int v) {
-    value_ = v;
-  }
 
   bool sign() const {
     return (bool) (value_ & 0x01);
@@ -71,7 +71,7 @@ public:
 
   void print() const;
 
-  unsigned raw() const { return value_;}
+  explicit operator unsigned() const { return value_;}
 
 private:
 
@@ -85,6 +85,8 @@ private:
 
   template <class _T> friend class LiteralIndexedVector;
 };
+
+
 
 /*!
  * Not-a-literal is a special literal.
@@ -206,7 +208,7 @@ public:
 
   //! Antecendant represents a literal
   Antecedent(const LiteralID idLit) {
-    val_ = (idLit.raw() << 1);
+    val_ = (static_cast<unsigned>(idLit) << 1);
   }
 
   bool isAClause() const {
@@ -218,9 +220,7 @@ public:
     }
 
   LiteralID asLit() {
-    LiteralID idLit;
-    idLit.copyRaw(val_ >> 1);
-    return idLit;
+    return LiteralID(val_ >> 1);
   }
   // A NON-Antecedent will only be A NOT_A_CLAUSE Clause Id
   bool isAnt() {

--- a/include/sharpSAT/structures.h
+++ b/include/sharpSAT/structures.h
@@ -30,16 +30,17 @@ public:
   LiteralID() {
     value_ = 0;
   }
-  LiteralID(int lit) {
+
+  explicit LiteralID(int lit) {
     value_ = (std::abs(lit) << 1) + (unsigned) (lit > 0);
   }
 
-  LiteralID(VariableIndex var, bool sign) {
-    value_ = (var << 1) + (unsigned) sign;
+  explicit LiteralID(VariableIndex var, bool sign) {
+    value_ = (static_cast<unsigned>(var) << 1) + (unsigned) sign;
   }
 
   VariableIndex var() const {
-    return (value_ >> 1);
+    return VariableIndex(value_ >> 1);
   }
 
   int toInt() const {
@@ -91,7 +92,7 @@ private:
  * It's represented as value 0, hence its
  * variable is the \ref varsSENTINEL.
  */
-static const LiteralID NOT_A_LIT(0, false);
+static const LiteralID NOT_A_LIT(VariableIndex(0), false);
 static const auto SENTINEL_LIT = NOT_A_LIT;
 
 class Literal {
@@ -200,7 +201,7 @@ public:
 
   //! Antecendant represents a clause
   Antecedent(const ClauseOfs cl_ofs) {
-     val_ = (cl_ofs << 1) | 1;
+     val_ = (static_cast<unsigned>(cl_ofs) << 1) | 1;
    }
 
   //! Antecendant represents a literal
@@ -213,7 +214,7 @@ public:
   }
 
   ClauseOfs asCl() const {
-      return val_ >> 1;
+      return ClauseOfs(val_ >> 1);
     }
 
   LiteralID asLit() {

--- a/include/sharpSAT/unions.h
+++ b/include/sharpSAT/unions.h
@@ -1,0 +1,218 @@
+/*
+ * unions.h
+ *
+ *  Created on: Jun 12, 2018
+ *      Author: Radomir Cernoch
+ */
+
+#ifndef SHARP_SAT_UNIONS_H_
+#define SHARP_SAT_UNIONS_H_
+
+#include <sharpSAT/structures.h>
+
+#include <type_traits>
+#include <functional>
+#include <limits>
+#include <tuple>
+
+
+namespace sharpSAT {
+
+namespace { // tools for Variant
+
+  //! Finds the index of `Needle` within `Head,Tail` (termination)
+  template<size_t Acc, class Needle, class Head, class... Tail>
+  static constexpr typename std::enable_if<
+    std::is_same<Needle,Head>::value,
+  unsigned char>::type variant_find_type() {
+    static_assert(Acc <= std::numeric_limits<unsigned char>::max(),
+      "variant takes at most numeric_limits<unsigned char>::max() types");
+    return static_cast<unsigned char>(Acc);
+  }
+
+  //! Finds the index of `Needle` within `Head,Tail` (recursive call)
+  template<size_t Acc, class Needle, class Head, class... Tail>
+  static constexpr typename std::enable_if<
+    ! std::is_same<Needle,Head>::value,
+  unsigned char>::type variant_find_type() {
+    return variant_find_type<Acc + 1, Needle, Tail...>();
+  }
+
+
+
+  //! Is one class-list a prefix-list of another class-list
+  template <typename ...A>
+  struct is_prefix : std::false_type { };
+
+  //! Is one class-list a prefix-list of another class-list
+  template <typename A1, typename ...Aother, typename B1, typename ...Bother>
+  struct is_prefix<std::tuple<A1, Aother...>, std::tuple<B1, Bother...>> {
+    static const bool value = std::is_same<A1, B1>::value
+                           && is_prefix<std::tuple<Aother...>,
+                                        std::tuple<Bother...>>::value;
+  };
+
+  //! Is one class-list a prefix-list of another class-list
+  template <typename ...B>
+  struct is_prefix<std::tuple<>, std::tuple<B...>> : std::true_type { };
+}
+
+template<class... Ts>
+struct ReleaseVariant {
+
+  //! Construct the variant by casting to `unsigned`
+  template<class T> ReleaseVariant(T object)
+  : data(static_cast<unsigned>(object)) {}
+
+  //! Copy constructor of uneven types
+  template<class... ProtoTs>
+  ReleaseVariant(const ReleaseVariant<ProtoTs...>& prototype)
+  : data(prototype.data) {
+    static_assert(is_prefix<std::tuple<ProtoTs...>, std::tuple<Ts...>>::value,
+      "If the prototype's variants are not a subclass of this variant's,"
+      " we can't match the type_id (in Debug mode).");
+  }
+
+  //! Raw constructor avoids all means of type-checking
+  ReleaseVariant(unsigned data, size_t) : data(data) {}
+
+  //! Construct the typed value and check the type (in debug mode)
+	template<class T> T get() const	{
+		return T(data);
+	}
+
+  //! Raw conversion avoids all means of type-checking
+  explicit operator unsigned() const {
+    return data;
+  }
+
+protected:
+
+  //! Value contained by this variant
+	unsigned data;
+
+  //! Let ReleaseVariant access \ref data if template args mismatch.
+  template<class... FriendTs>
+  friend class ReleaseVariant;
+}; // ReleaseVariant
+
+
+
+template<class... Ts>
+struct DebugVariant : public ReleaseVariant<Ts...> {
+
+  //! Construct the variant and store the type (in debug mode)
+  template<class T>
+	DebugVariant(T object)
+  : ReleaseVariant<Ts...>(object)
+  , type_id(variant_find_type<0,T,Ts...>())
+  {}
+
+  //! Copy constructor works only if \ref type_id does match
+  template<class... ProtoTs>
+  DebugVariant(const DebugVariant<ProtoTs...>& prototype)
+  : ReleaseVariant<Ts...>(static_cast<unsigned>(prototype))
+  , type_id(prototype.type_id)
+  {
+    static_assert(is_prefix<std::tuple<ProtoTs...>, std::tuple<Ts...>>::value,
+      "If the prototype's variants are not a subclass of this variant's,"
+      " we can't match the type_id (in Debug mode).");
+  }
+
+  /*!
+   * Raw constructor avoids all means of type-checking.
+   *
+   * Only use, if the `type_id` matches the type of the value.
+   */
+  DebugVariant(unsigned data, size_t type_id)
+  : ReleaseVariant<Ts...>(data, type_id)
+  , type_id(type_id)
+  {}
+
+  //! Construct the typed value and check the type (in debug mode)
+	template<class T> T get() const	{
+		assert((type_id == variant_find_type<0,T,Ts...>())
+      && "Variant was written a different type than is being read.");
+		return T(ReleaseVariant<Ts...>::data);
+	}
+
+protected:
+
+  //! Index of the current type within `Ts`
+	unsigned char type_id;
+
+  //! Check if the expected type is the one
+  void assert_type_matches(unsigned char expected_type) const
+  {
+    assert(type_id == expected_type
+      && "Trying to extract a wrong type from the variant");
+	}
+
+  //! Let DebugVariant access \ref type_id if template args mismatch.
+  template<class... FriendTs>
+  friend struct DebugVariant;
+}; // DebugVariant
+
+
+
+#if !defined(NDEBUG)
+template<class... Ts>
+using Variant = DebugVariant<Ts...>;
+#else
+template<class... Ts>
+using Variant = ReleaseVariant<Ts...>;
+#endif
+
+
+
+struct ClauseOrVariable {
+  ClauseOrVariable(ClauseIndex cls) : v_(cls) {}
+  ClauseOrVariable(VariableIndex var) : v_(var) {}
+  ClauseIndex cls() const { return v_.get<ClauseIndex>(); }
+  VariableIndex var() const { return v_.get<VariableIndex>(); }
+  explicit operator unsigned() const { return static_cast<unsigned>(v_); }
+private:
+  Variant<ClauseIndex,VariableIndex> v_;
+}; // ClauseOrVariable
+
+struct ClauseOrLiteral {
+  ClauseOrLiteral(ClauseIndex cls) : v_(cls) {}
+  ClauseOrLiteral(LiteralID lit) : v_(lit) {}
+  ClauseIndex cls() const { return v_.get<ClauseIndex>(); }
+  LiteralID lit() const { return v_.get<LiteralID>(); }
+private:
+  Variant<ClauseIndex,LiteralID> v_;
+  friend class ClauseOrLiteralOrVariable;
+}; // ClauseOrVariable
+
+struct ClauseOrLiteralOrVariable {
+  ClauseOrLiteralOrVariable(ClauseIndex cls) : v_(cls) {}
+  ClauseOrLiteralOrVariable(LiteralID lit) : v_(lit) {}
+  ClauseOrLiteralOrVariable(VariableIndex var) : v_(var) {}
+  ClauseOrLiteralOrVariable(unsigned i) : v_(i) {}
+
+  //! Construct from \ref ClauseOrLiteral
+  ClauseOrLiteralOrVariable(const ClauseOrLiteral& col) : v_(col.v_) {}
+
+  explicit operator unsigned() const { return static_cast<unsigned>(v_); }
+  ClauseIndex cls() const { return v_.get<ClauseIndex>(); }
+  LiteralID lit() const { return v_.get<LiteralID>(); }
+  VariableIndex var() const { return v_.get<VariableIndex>(); }
+private:
+  Variant<ClauseIndex,LiteralID,VariableIndex,unsigned> v_;
+}; // ClauseOrLiteralOrVariable
+
+struct ClauseOfsOrVariable {
+  ClauseOfsOrVariable(unsigned i) : v_(i) {}
+  ClauseOfsOrVariable(ClauseOfs ofs) : v_(ofs) {}
+  ClauseOfsOrVariable(VariableIndex var) : v_(var) {}
+  ClauseOfs ofs() const { return v_.get<ClauseOfs>(); }
+  VariableIndex var() const { return v_.get<VariableIndex>(); }
+  explicit operator unsigned() const { return static_cast<unsigned>(v_); }
+
+private:
+  Variant<unsigned,ClauseOfs,VariableIndex> v_;
+}; // ClauseOfsOrVariable
+
+} // sharpSAT namespace
+#endif // SHARP_SAT_UNIONS_H_

--- a/include/sharpSAT/unions.h
+++ b/include/sharpSAT/unions.h
@@ -163,56 +163,5 @@ template<class... Ts>
 using Variant = ReleaseVariant<Ts...>;
 #endif
 
-
-
-struct ClauseOrVariable {
-  ClauseOrVariable(ClauseIndex cls) : v_(cls) {}
-  ClauseOrVariable(VariableIndex var) : v_(var) {}
-  ClauseIndex cls() const { return v_.get<ClauseIndex>(); }
-  VariableIndex var() const { return v_.get<VariableIndex>(); }
-  explicit operator unsigned() const { return static_cast<unsigned>(v_); }
-private:
-  Variant<ClauseIndex,VariableIndex> v_;
-}; // ClauseOrVariable
-
-struct ClauseOrLiteral {
-  ClauseOrLiteral(ClauseIndex cls) : v_(cls) {}
-  ClauseOrLiteral(LiteralID lit) : v_(lit) {}
-  ClauseIndex cls() const { return v_.get<ClauseIndex>(); }
-  LiteralID lit() const { return v_.get<LiteralID>(); }
-private:
-  Variant<ClauseIndex,LiteralID> v_;
-  friend class ClauseOrLiteralOrVariable;
-}; // ClauseOrVariable
-
-struct ClauseOrLiteralOrVariable {
-  ClauseOrLiteralOrVariable(ClauseIndex cls) : v_(cls) {}
-  ClauseOrLiteralOrVariable(LiteralID lit) : v_(lit) {}
-  ClauseOrLiteralOrVariable(VariableIndex var) : v_(var) {}
-  ClauseOrLiteralOrVariable(unsigned i) : v_(i) {}
-
-  //! Construct from \ref ClauseOrLiteral
-  ClauseOrLiteralOrVariable(const ClauseOrLiteral& col) : v_(col.v_) {}
-
-  explicit operator unsigned() const { return static_cast<unsigned>(v_); }
-  ClauseIndex cls() const { return v_.get<ClauseIndex>(); }
-  LiteralID lit() const { return v_.get<LiteralID>(); }
-  VariableIndex var() const { return v_.get<VariableIndex>(); }
-private:
-  Variant<ClauseIndex,LiteralID,VariableIndex,unsigned> v_;
-}; // ClauseOrLiteralOrVariable
-
-struct ClauseOfsOrVariable {
-  ClauseOfsOrVariable(unsigned i) : v_(i) {}
-  ClauseOfsOrVariable(ClauseOfs ofs) : v_(ofs) {}
-  ClauseOfsOrVariable(VariableIndex var) : v_(var) {}
-  ClauseOfs ofs() const { return v_.get<ClauseOfs>(); }
-  VariableIndex var() const { return v_.get<VariableIndex>(); }
-  explicit operator unsigned() const { return static_cast<unsigned>(v_); }
-
-private:
-  Variant<unsigned,ClauseOfs,VariableIndex> v_;
-}; // ClauseOfsOrVariable
-
 } // sharpSAT namespace
 #endif // SHARP_SAT_UNIONS_H_

--- a/src/alt_component_analyzer.cpp
+++ b/src/alt_component_analyzer.cpp
@@ -26,8 +26,8 @@ void AltComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
   variable_link_list_offsets_.resize(max_variable_id + 1, 0);
 
   VariableIndexedVector<vector<ClauseIndex>> occs(max_variable_id + 1);
-  VariableIndexedVector<vector<unsigned>> occ_long_clauses(max_variable_id + 1);
-  VariableIndexedVector<vector<unsigned>> occ_ternary_clauses(max_variable_id + 1);
+  VariableIndexedVector<vector<ClauseOrLiteral>> occ_long_clauses(max_variable_id + 1);
+  VariableIndexedVector<vector<ClauseOrLiteral>> occ_ternary_clauses(max_variable_id + 1);
 
   vector<LiteralID> tmp;
   max_clause_id_ = ClauseIndex(0);
@@ -57,22 +57,22 @@ void AltComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
         auto& target = occ_ternary_clauses[it_lit->var()];
         target.reserve(target.size() + 1 + tmp.size());
 
-        target.push_back(static_cast<unsigned>(max_clause_id_));
+        target.push_back(max_clause_id_);
         for (LiteralID lit : tmp) {
-          target.push_back(lit.raw());
+          target.push_back(lit);
         }
       } else {
         assert(tmp.size() >= 3);
-        occs[it_lit->var()].push_back((max_clause_id_));
+        occs[it_lit->var()].push_back(max_clause_id_);
         occs[it_lit->var()].push_back(ClauseIndex(occ_long_clauses[it_lit->var()].size()));
 
         auto& target = occ_long_clauses[it_lit->var()];
         target.reserve(target.size() + 1 + tmp.size());
 
         for (LiteralID lit : tmp) {
-          target.push_back(lit.raw());
+          target.push_back(lit);
         }
-        target.push_back(static_cast<unsigned>(clsSENTINEL));
+        target.push_back(clsSENTINEL);
       }
     }
   }
@@ -80,45 +80,46 @@ void AltComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
   ComponentArchetype::initArrays(max_variable_id_, max_clause_id_);
   // the unified link list
   unified_variable_links_lists_pool_.clear();
-  unified_variable_links_lists_pool_.push_back(0);
-  unified_variable_links_lists_pool_.push_back(0);
+  unified_variable_links_lists_pool_.push_back(0); // never accessed
+  unified_variable_links_lists_pool_.push_back(0); // never accessed
+
   for (VariableIndex v(1); v < VariableIndex(occs.size()); v++) {
     // BEGIN data for binary clauses
     variable_link_list_offsets_[v] = unified_variable_links_lists_pool_.size();
     for (auto l : literals[LiteralID(v, false)].binary_links_)
       if (l != SENTINEL_LIT)
-        unified_variable_links_lists_pool_.push_back(static_cast<unsigned>(l.var()));
+        unified_variable_links_lists_pool_.push_back(l.var());
 
     for (auto l : literals[LiteralID(v, true)].binary_links_)
       if (l != SENTINEL_LIT)
-        unified_variable_links_lists_pool_.push_back(static_cast<unsigned>(l.var()));
+        unified_variable_links_lists_pool_.push_back(l.var());
 
-    unified_variable_links_lists_pool_.push_back(0);
+    unified_variable_links_lists_pool_.push_back(varsSENTINEL);
 
     // BEGIN data for ternary clauses
     unified_variable_links_lists_pool_.insert(
         unified_variable_links_lists_pool_.end(),
         occ_ternary_clauses[v].begin(),
-        occ_ternary_clauses[v].end());
-
+        occ_ternary_clauses[v].end()
+    );
+    // This can't be typed using ClauseOrVariableOrLiteral,
+    // because the previous items are either Clause or a Literal
+    // (not 1 concrete type).
     unified_variable_links_lists_pool_.push_back(0);
 
     // BEGIN data for long clauses
     for(auto it = occs[v].begin(); it != occs[v].end(); it+=2){
-      unified_variable_links_lists_pool_.push_back(static_cast<unsigned>(*it));
-      unified_variable_links_lists_pool_.push_back(static_cast<unsigned>(*(it + 1)) + (occs[v].end() - it));
+      unified_variable_links_lists_pool_.push_back(*it);
+      unified_variable_links_lists_pool_.push_back(*(it + 1) + ClauseIndex(occs[v].end() - it));
     }
-
-    unified_variable_links_lists_pool_.push_back(0);
+    unified_variable_links_lists_pool_.push_back(clsSENTINEL);
 
     unified_variable_links_lists_pool_.insert(
         unified_variable_links_lists_pool_.end(),
         occ_long_clauses[v].begin(),
-        occ_long_clauses[v].end());
+        occ_long_clauses[v].end()
+    );
   }
-
-
-
 }
 
 
@@ -173,35 +174,34 @@ void AltComponentAnalyzer::recordComponentOf(const VariableIndex var) {
     //BEGIN traverse binary clauses
     assert(isActive(*vt));
     auto p = beginOfLinkList(*vt);
-    for (; *p; p++) {
-      if(manageSearchOccurrenceOf(LiteralID(VariableIndex(*p),true))){
-        var_frequency_scores_[VariableIndex(*p)]++;
+    for (; p->var() != varsSENTINEL; p++) {
+      if(manageSearchOccurrenceOf(LiteralID(p->var(),true))){
+        var_frequency_scores_[p->var()]++;
         var_frequency_scores_[*vt]++;
       }
     }
     //END traverse binary clauses
 
-    for ( p++; *p ; p+=3) {
-      if(archetype_.clause_unseen_in_sup_comp(ClauseIndex(*p))) {
-        LiteralID litA, litB;
-        litA.copyRaw(*(p + 1));
-        litB.copyRaw(*(p + 2));
+    for ( p++; static_cast<unsigned>(*p) ; p+=3) {
+      if(archetype_.clause_unseen_in_sup_comp(p->cls())) {
+        LiteralID litA = (p + 1)->lit();
+        LiteralID litB = (p + 2)->lit();
         if(isSatisfied(litA)|| isSatisfied(litB))
-          archetype_.setClause_nil(ClauseIndex(*p));
+          archetype_.setClause_nil(p->cls());
         else {
           var_frequency_scores_[*vt]++;
           manageSearchOccurrenceAndScoreOf(litA);
           manageSearchOccurrenceAndScoreOf(litB);
-          archetype_.setClause_seen(ClauseIndex(*p),
+          archetype_.setClause_seen(p->cls(),
               isActive(litA) & isActive(litB));
         }
       }
     }
     //END traverse ternary clauses
 
-    for (p++; *p ; p +=2)
-      if(archetype_.clause_unseen_in_sup_comp(ClauseIndex(*p)))
-        searchClause(*vt,ClauseIndex(*p), p + 1 + *(p+1));
+    for (p++; p->cls() != clsSENTINEL; p +=2)
+      if(archetype_.clause_unseen_in_sup_comp(p->cls()))
+        searchClause(*vt, p->cls(), p + 1 + static_cast<unsigned>((p+1)->cls()));
   }
 }
 

--- a/src/alt_component_analyzer.cpp
+++ b/src/alt_component_analyzer.cpp
@@ -172,7 +172,7 @@ void AltComponentAnalyzer::recordComponentOf(const VariableIndex var) {
   for (auto vt = search_stack_.begin(); vt != search_stack_.end(); vt++) {
     //BEGIN traverse binary clauses
     assert(isActive(*vt));
-    unsigned *p = beginOfLinkList(*vt);
+    auto p = beginOfLinkList(*vt);
     for (; *p; p++) {
       if(manageSearchOccurrenceOf(LiteralID(VariableIndex(*p),true))){
         var_frequency_scores_[VariableIndex(*p)]++;
@@ -183,8 +183,9 @@ void AltComponentAnalyzer::recordComponentOf(const VariableIndex var) {
 
     for ( p++; *p ; p+=3) {
       if(archetype_.clause_unseen_in_sup_comp(ClauseIndex(*p))) {
-        LiteralID litA = *reinterpret_cast<const LiteralID *>(p + 1);
-        LiteralID litB = *(reinterpret_cast<const LiteralID *>(p + 1) + 1);
+        LiteralID litA, litB;
+        litA.copyRaw(*(p + 1));
+        litB.copyRaw(*(p + 2));
         if(isSatisfied(litA)|| isSatisfied(litB))
           archetype_.setClause_nil(ClauseIndex(*p));
         else {
@@ -200,7 +201,7 @@ void AltComponentAnalyzer::recordComponentOf(const VariableIndex var) {
 
     for (p++; *p ; p +=2)
       if(archetype_.clause_unseen_in_sup_comp(ClauseIndex(*p)))
-        searchClause(*vt,ClauseIndex(*p), reinterpret_cast<LiteralID *>(p + 1 + *(p+1)));
+        searchClause(*vt,ClauseIndex(*p), p + 1 + *(p+1));
   }
 }
 

--- a/src/alt_component_analyzer.cpp
+++ b/src/alt_component_analyzer.cpp
@@ -40,7 +40,7 @@ void AltComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
       if (it_lit + 1 == lit_pool.end())
         break;
 
-      max_clause_id_++;
+      ++max_clause_id_;
       it_lit += ClauseHeader::overheadInLits();
       it_curr_cl_st = it_lit + 1;
       curr_clause_length = 0;
@@ -83,7 +83,7 @@ void AltComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
   unified_variable_links_lists_pool_.push_back(0u);
   unified_variable_links_lists_pool_.push_back(0u);
 
-  for (VariableIndex v(1); v < VariableIndex(occs.size()); v++) {
+  for (VariableIndex v(1); v < VariableIndex(occs.size()); ++v) {
     // BEGIN data for binary clauses
     variable_link_list_offsets_[v] = unified_variable_links_lists_pool_.size();
     for (auto l : literals[LiteralID(v, false)].binary_links_)

--- a/src/component_analyzer.cpp
+++ b/src/component_analyzer.cpp
@@ -66,8 +66,8 @@ void STDComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
   ComponentArchetype::initArrays(max_variable_id_, max_clause_id_);
   // the unified link list
   unified_variable_links_lists_pool_.clear();
-  unified_variable_links_lists_pool_.push_back(0);
-  unified_variable_links_lists_pool_.push_back(0);
+  unified_variable_links_lists_pool_.push_back(0u);
+  unified_variable_links_lists_pool_.push_back(0u);
 
   for (VariableIndex v(1); v < VariableIndex(occs_.size()); v++) {
     variable_link_list_offsets_[v] = unified_variable_links_lists_pool_.size();
@@ -109,10 +109,10 @@ void STDComponentAnalyzer::recordComponentOf(const VariableIndex var) {
     //BEGIN traverse binary clauses
     assert(isActive(*vt));
     auto pvar = beginOfLinkList(*vt);
-    for (; pvar->var() != varsSENTINEL; pvar++) {
-      if(isUnseenAndActive(pvar->var())) {
-        setSeenAndStoreInSearchStack(pvar->var());
-        var_frequency_scores_[pvar->var()]++;
+    for (; pvar->get<VariableIndex>() != varsSENTINEL; pvar++) {
+      if(isUnseenAndActive(pvar->get<VariableIndex>())) {
+        setSeenAndStoreInSearchStack(pvar->get<VariableIndex>());
+        var_frequency_scores_[pvar->get<VariableIndex>()]++;
         var_frequency_scores_[*vt]++;
       }
     }
@@ -121,13 +121,13 @@ void STDComponentAnalyzer::recordComponentOf(const VariableIndex var) {
     // start traversing links to long clauses
     // not that that list starts right after the 0 termination of the prvious list
     // hence  pcl_ofs = pvar + 1
-    for (auto pcl_ofs = pvar + 1; pcl_ofs->ofs() != SENTINEL_CL; pcl_ofs++) {
+    for (auto pcl_ofs = pvar + 1; pcl_ofs->get<ClauseOfs>() != SENTINEL_CL; pcl_ofs++) {
       // Type-safety problem. Is pcl_ofs a ClauseOfs or ClauseIndex?
-      ClauseIndex clID = getClauseID(pcl_ofs->ofs());
+      ClauseIndex clID = getClauseID(pcl_ofs->get<ClauseOfs>());
       if(archetype_.clause_unseen_in_sup_comp(clID)){
         auto itVEnd = search_stack_.end();
         bool all_lits_active = true;
-        for (auto itL = beginOfClause(pcl_ofs->ofs()); *itL != SENTINEL_LIT; itL++) {
+        for (auto itL = beginOfClause(pcl_ofs->get<ClauseOfs>()); *itL != SENTINEL_LIT; itL++) {
           assert(itL->var() <= max_variable_id_);
           if(archetype_.var_nil(itL->var())){
             assert(!isActive(*itL));
@@ -141,7 +141,7 @@ void STDComponentAnalyzer::recordComponentOf(const VariableIndex var) {
               search_stack_.pop_back();
             }
             archetype_.setClause_nil(clID);
-            for (auto itX = beginOfClause(pcl_ofs->ofs()); itX != itL; itX++) {
+            for (auto itX = beginOfClause(pcl_ofs->get<ClauseOfs>()); itX != itL; itX++) {
               if (var_frequency_scores_[itX->var()] > 0)
                 var_frequency_scores_[itX->var()]--;
             }

--- a/src/component_analyzer.cpp
+++ b/src/component_analyzer.cpp
@@ -108,7 +108,7 @@ void STDComponentAnalyzer::recordComponentOf(const VariableIndex var) {
     // the for-loop is applicable here because componentSearchStack.capacity() == countAllVars()
     //BEGIN traverse binary clauses
     assert(isActive(*vt));
-    unsigned *pvar = beginOfLinkList(*vt);
+    auto pvar = beginOfLinkList(*vt);
     for (; *pvar; pvar++) {
       if(isUnseenAndActive(VariableIndex(*pvar))) {
         setSeenAndStoreInSearchStack(VariableIndex(*pvar));

--- a/src/component_analyzer.cpp
+++ b/src/component_analyzer.cpp
@@ -43,7 +43,7 @@ void STDComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
         break;
       }
 
-      max_clause_id_++;
+      ++max_clause_id_;
       literal_pool_.push_back(SENTINEL_LIT);
       for (unsigned i = 0; i < CAClauseHeader::overheadInLits(); i++)
         literal_pool_.push_back(LiteralID());
@@ -69,7 +69,7 @@ void STDComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
   unified_variable_links_lists_pool_.push_back(0u);
   unified_variable_links_lists_pool_.push_back(0u);
 
-  for (VariableIndex v(1); v < VariableIndex(occs_.size()); v++) {
+  for (VariableIndex v(1); v < VariableIndex(occs_.size()); ++v) {
     variable_link_list_offsets_[v] = unified_variable_links_lists_pool_.size();
 
     for (auto l : literals[LiteralID(v, false)].binary_links_)

--- a/src/component_analyzer.cpp
+++ b/src/component_analyzer.cpp
@@ -52,7 +52,7 @@ void STDComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
       it_lit += ClauseHeader::overheadInLits();
       curr_clause_length = 0;
 
-      assert(map_clause_id_to_ofs_.size() == static_cast<unsigned>(max_clause_id_));
+      assert(ClauseIndex(map_clause_id_to_ofs_.size()) == max_clause_id_);
       map_clause_id_to_ofs_.push_back(current_clause_ofs);
 
     } else {
@@ -68,26 +68,26 @@ void STDComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
   unified_variable_links_lists_pool_.clear();
   unified_variable_links_lists_pool_.push_back(0);
   unified_variable_links_lists_pool_.push_back(0);
+
   for (VariableIndex v(1); v < VariableIndex(occs_.size()); v++) {
     variable_link_list_offsets_[v] = unified_variable_links_lists_pool_.size();
+
     for (auto l : literals[LiteralID(v, false)].binary_links_)
       if (l != SENTINEL_LIT) {
-        unified_variable_links_lists_pool_.push_back(static_cast<unsigned>(l.var()));
+        unified_variable_links_lists_pool_.push_back(l.var());
       }
     for (auto l : literals[LiteralID(v, true)].binary_links_)
       if (l != SENTINEL_LIT) {
-        unified_variable_links_lists_pool_.push_back(static_cast<unsigned>(l.var()));
+        unified_variable_links_lists_pool_.push_back(l.var());
       }
-    unified_variable_links_lists_pool_.push_back(0);
+    unified_variable_links_lists_pool_.push_back(varsSENTINEL);
 
-    unified_variable_links_lists_pool_.reserve(
-      unified_variable_links_lists_pool_.size()
-      + occs_[v].size() );
-    for (ClauseOfs cl_ofs : occs_[v]) {
-      unified_variable_links_lists_pool_.push_back(static_cast<unsigned>(cl_ofs));
-    }
+    unified_variable_links_lists_pool_.insert(
+        unified_variable_links_lists_pool_.end(),
+        occs_[v].begin(),
+        occs_[v].end());
 
-    unified_variable_links_lists_pool_.push_back(0);
+    unified_variable_links_lists_pool_.push_back(SENTINEL_CL);
   }
 }
 
@@ -109,10 +109,10 @@ void STDComponentAnalyzer::recordComponentOf(const VariableIndex var) {
     //BEGIN traverse binary clauses
     assert(isActive(*vt));
     auto pvar = beginOfLinkList(*vt);
-    for (; *pvar; pvar++) {
-      if(isUnseenAndActive(VariableIndex(*pvar))) {
-        setSeenAndStoreInSearchStack(VariableIndex(*pvar));
-        var_frequency_scores_[VariableIndex(*pvar)]++;
+    for (; pvar->var() != varsSENTINEL; pvar++) {
+      if(isUnseenAndActive(pvar->var())) {
+        setSeenAndStoreInSearchStack(pvar->var());
+        var_frequency_scores_[pvar->var()]++;
         var_frequency_scores_[*vt]++;
       }
     }
@@ -121,13 +121,13 @@ void STDComponentAnalyzer::recordComponentOf(const VariableIndex var) {
     // start traversing links to long clauses
     // not that that list starts right after the 0 termination of the prvious list
     // hence  pcl_ofs = pvar + 1
-    for (auto pcl_ofs = pvar + 1; ClauseOfs(*pcl_ofs) != SENTINEL_CL; pcl_ofs++) {
+    for (auto pcl_ofs = pvar + 1; pcl_ofs->ofs() != SENTINEL_CL; pcl_ofs++) {
       // Type-safety problem. Is pcl_ofs a ClauseOfs or ClauseIndex?
-      ClauseIndex clID = getClauseID(ClauseOfs(*pcl_ofs));
+      ClauseIndex clID = getClauseID(pcl_ofs->ofs());
       if(archetype_.clause_unseen_in_sup_comp(clID)){
         auto itVEnd = search_stack_.end();
         bool all_lits_active = true;
-        for (auto itL = beginOfClause(ClauseOfs(*pcl_ofs)); *itL != SENTINEL_LIT; itL++) {
+        for (auto itL = beginOfClause(pcl_ofs->ofs()); *itL != SENTINEL_LIT; itL++) {
           assert(itL->var() <= max_variable_id_);
           if(archetype_.var_nil(itL->var())){
             assert(!isActive(*itL));
@@ -141,7 +141,7 @@ void STDComponentAnalyzer::recordComponentOf(const VariableIndex var) {
               search_stack_.pop_back();
             }
             archetype_.setClause_nil(clID);
-            for (auto itX = beginOfClause(ClauseOfs(*pcl_ofs)); itX != itL; itX++) {
+            for (auto itX = beginOfClause(pcl_ofs->ofs()); itX != itL; itX++) {
               if (var_frequency_scores_[itX->var()] > 0)
                 var_frequency_scores_[itX->var()]--;
             }

--- a/src/component_management.cpp
+++ b/src/component_management.cpp
@@ -19,7 +19,7 @@ void ComponentManager::initialize(LiteralIndexedVector<Literal> & literals,
   CacheableComponent::adjustPackSize(ana_.max_variable_id(), ana_.max_clause_id());
 
   component_stack_.clear();
-  component_stack_.reserve(ana_.max_variable_id() + 2);
+  component_stack_.reserve(static_cast<unsigned>(ana_.max_variable_id()) + 2);
   component_stack_.push_back(new Component());
   component_stack_.push_back(new Component());
   assert(component_stack_.size() == 2);

--- a/src/component_types/base_packed_component.cpp
+++ b/src/component_types/base_packed_component.cpp
@@ -19,13 +19,14 @@ unsigned BasePackedComponent::_bits_of_data_size=0;
 unsigned BasePackedComponent::_data_size_mask = 0;
 
 
-void BasePackedComponent::adjustPackSize(unsigned int maxVarId,
-    unsigned int maxClId) {
+void BasePackedComponent::adjustPackSize(VariableIndex maxVarId,
+    ClauseIndex maxClId) {
 
-  _bits_per_variable = log2(maxVarId) + 1;
-  _bits_per_clause   = log2(maxClId) + 1;
+  _bits_per_variable = log2(static_cast<unsigned>(maxVarId)) + 1;
+  _bits_per_clause   = log2(static_cast<unsigned>(maxClId)) + 1;
 
-  _bits_of_data_size = log2(maxVarId + maxClId) + 1;
+  _bits_of_data_size = log2(static_cast<unsigned>(maxVarId)
+                          + static_cast<unsigned>(maxClId) ) + 1;
 
   _variable_mask = _clause_mask = _data_size_mask = 0;
   for (unsigned int i = 0; i < _bits_per_variable; i++)

--- a/src/instance.cpp
+++ b/src/instance.cpp
@@ -121,13 +121,13 @@ void Instance::compactVariables() {
     _tmp_bin_links.push_back(l.binary_links_);
 
   assert(_tmp_bin_links.size() == literals_.size());
-  for (VariableIndex v(1); v < VariableIndex(variables_.size()); v++)
+  for (VariableIndex v(1); v < VariableIndex(variables_.size()); ++v)
     if (isActive(LiteralID(v, true))) {
       if (isolated(v)) {
         num_isolated++;
         continue;
       }
-      last_ofs++;
+      ++last_ofs;
       var_map[v] = last_ofs;
     }
 

--- a/src/new_component_analyzer.cpp
+++ b/src/new_component_analyzer.cpp
@@ -43,7 +43,7 @@ void NewComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
         break;
       }
 
-      max_clause_id_++;
+      ++max_clause_id_;
       literal_pool_.push_back(SENTINEL_LIT);
       for (unsigned i = 0; i < CAClauseHeader::overheadInLits(); i++)
         literal_pool_.push_back(LiteralID(0));
@@ -74,7 +74,7 @@ void NewComponentAnalyzer::initialize(LiteralIndexedVector<Literal> & literals,
   unified_variable_links_lists_pool_.push_back(0u);
   unified_variable_links_lists_pool_.push_back(0u);
 
-  for (VariableIndex v(1); v < VariableIndex(occs_.size()); v++) {
+  for (VariableIndex v(1); v < VariableIndex(occs_.size()); ++v) {
     variable_link_list_offsets_[v] = unified_variable_links_lists_pool_.size();
     for (auto l : literals[LiteralID(v, false)].binary_links_)
       if (l != SENTINEL_LIT) {

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -216,11 +216,11 @@ void Solver::decideLiteral() {
 	VariableIndex max_score_var(0);
 	for (auto it =
 			comp_manager_.superComponentOf(stack_.top()).varsBegin();
-			VariableIndex(*it) != varsSENTINEL; it++) {
-		score = scoreOf(VariableIndex(*it));
+			it->var() != varsSENTINEL; it++) {
+		score = scoreOf(it->var());
 		if (score > max_score) {
 			max_score = score;
-			max_score_var = VariableIndex(*it);
+			max_score_var = it->var();
 		}
 	}
 	// this assert should always hold,

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -216,11 +216,11 @@ void Solver::decideLiteral() {
 	VariableIndex max_score_var(0);
 	for (auto it =
 			comp_manager_.superComponentOf(stack_.top()).varsBegin();
-			it->var() != varsSENTINEL; it++) {
-		score = scoreOf(it->var());
+			it->get<VariableIndex>() != varsSENTINEL; it++) {
+		score = scoreOf(it->get<VariableIndex>());
 		if (score > max_score) {
 			max_score = score;
-			max_score_var = it->var();
+			max_score_var = it->get<VariableIndex>();
 		}
 	}
 	// this assert should always hold,

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -50,7 +50,7 @@ bool Solver::prepFailedLiteralTest() {
 	unsigned last_size;
 	do {
 		last_size = literal_stack_.size();
-		for (VariableIndex v(1); v < VariableIndex(variables_.size()); v++)
+		for (VariableIndex v(1); v < VariableIndex(variables_.size()); ++v)
 		    if (isActive(LiteralID(v, true))) {
 				unsigned sz = literal_stack_.size();
 				setLiteralIfFree(LiteralID(v, true));

--- a/src/structures.cpp
+++ b/src/structures.cpp
@@ -9,7 +9,7 @@ static_assert((sizeof(ClauseHeader) / sizeof(LiteralID)) * sizeof(LiteralID) == 
 
 
 void LiteralID::print() const {
-  std::cout << (sign() ? " " : "-") << var() << " ";
+  std::cout << (sign() ? " " : "-") << static_cast<unsigned>(var()) << " ";
 }
 
 } // end namespace sharpSAT


### PR DESCRIPTION
- **Motivation:** Code should be easier to read.
- **Means:** Conversions between "primitive" types are explicit.
- Some confusion between `ClauseOfs` and `ClauseIndex` are clarified.
- Only the `CacheEntryID` remains weak-typed (too much refactoring, too little effect).
- No performance regression has been found.